### PR TITLE
Fix missing query string in WebSocket handshake

### DIFF
--- a/src/main/java/com/testingbot/tunnel/proxy/WebsocketHandler.java
+++ b/src/main/java/com/testingbot/tunnel/proxy/WebsocketHandler.java
@@ -112,7 +112,11 @@ public class WebsocketHandler extends HandlerWrapper {
     private Map<String, String> performWebSocketHandshake(HttpServletRequest clientRequest, SocketChannel channel) throws IOException {
         // Send WebSocket upgrade request to target
         StringBuilder requestHeaders = new StringBuilder();
-        requestHeaders.append(clientRequest.getMethod()).append(" ").append(clientRequest.getRequestURI()).append(" ").append(clientRequest.getProtocol()).append("\r\n");
+        requestHeaders.append(clientRequest.getMethod()).append(" ").append(clientRequest.getRequestURI());
+        if (clientRequest.getQueryString() != null) {
+            requestHeaders.append("?").append(clientRequest.getQueryString());
+        }
+        requestHeaders.append(" ").append(clientRequest.getProtocol()).append("\r\n");
         for (String headerName : Collections.list(clientRequest.getHeaderNames())) {
             requestHeaders.append(headerName).append(": ").append(clientRequest.getHeader(headerName)).append("\r\n");
         }


### PR DESCRIPTION
This PR fixes the WebSocket handshake implementation not forwarding the request's query string, breaking any protocol relying on it, such as [Vitest](https://github.com/vitest-dev/vitest/blob/286851ea2ce3d57f5cfd638fbbb98f15c708821e/packages/vitest/src/api/check.ts#L10).
