### PR TITLE
Thin main jar + manual Maven Central publish workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,38 @@
+name: Publish to Maven Central
+
+# Manually publish the current POM version to Maven Central, without creating a
+# GitHub release or Docker image (use this to publish a version that was already
+# tagged/released on GitHub, e.g. 4.8). Select the branch to run from in the
+# "Run workflow" dropdown — it publishes whatever version the checked-out POM has.
+#
+# NOTE: Maven Central versions are immutable. Only run this from a branch whose
+# build produces the thin main jar (i.e. after the thin-jar change is merged).
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'maven'
+        server-id: central
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_PASSWORD
+        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+        gpg-passphrase: GPG_PASSPHRASE
+
+    - name: Build and deploy to Maven Central
+      run: mvn -B clean deploy -DskipTests -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+      env:
+        MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -10,16 +10,26 @@ name: Publish to Maven Central
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+# Never deploy two publishes to Central at the same time; queue instead of racing.
+concurrency:
+  group: maven-central-publish
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         java-version: '11'
         distribution: 'temurin'
@@ -31,7 +41,7 @@ jobs:
         gpg-passphrase: GPG_PASSPHRASE
 
     - name: Build and deploy to Maven Central
-      run: mvn -B clean deploy -DskipTests -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+      run: mvn -B clean deploy -DskipTests
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,19 @@ jobs:
         MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-    # Upload the JAR as a release asset
+    # The published Maven artifact is now the thin jar; use the runnable "shaded" jar as the
+    # downloadable CLI release asset, keeping the familiar TestingBotTunnel-<version>.jar name.
+    - name: Prepare runnable jar for release
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/v}
+        mkdir -p release-assets
+        cp target/TestingBotTunnel-${VERSION}-shaded.jar release-assets/TestingBotTunnel-${VERSION}.jar
+
+    # Upload the runnable JAR as a release asset
     - name: Upload JAR to GitHub Releases
       uses: softprops/action-gh-release@v1
       with:
-        files: target/TestingBotTunnel-*.jar
+        files: release-assets/TestingBotTunnel-*.jar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
     # Upload the runnable JAR as a release asset
     - name: Upload JAR to GitHub Releases
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
       with:
         files: release-assets/TestingBotTunnel-*.jar
       env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mvn -B -ntp -DskipTests \
         -Dmaven.javadoc.skip=true \
         -Dmaven.source.skip=true \
         package \
-    && mv target/TestingBotTunnel-*.jar target/testingbot-tunnel.jar
+    && mv target/TestingBotTunnel-*-shaded.jar target/testingbot-tunnel.jar
 
 # -------- Runtime stage --------
 FROM eclipse-temurin:11-jre-jammy

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,12 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <!-- Publish a thin main artifact (project classes only, with dependencies declared
+                   in the POM) so Maven consumers such as the Jenkins plugin get the real, correctly
+                   versioned dependencies transitively instead of a fat jar that shadows them.
+                   The runnable uber jar is attached under the "shaded" classifier for CLI/Docker use. -->
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>shaded</shadedClassifierName>
               <minimizeJar>true</minimizeJar>
               <filters>
                 <filter>
@@ -254,7 +260,7 @@
               <executable>java</executable>
               <arguments>
                 <argument>-jar</argument>
-                <argument>${project.build.directory}/${project.build.finalName}.jar</argument>
+                <argument>${project.build.directory}/${project.build.finalName}-shaded.jar</argument>
                 <argument>--version</argument>
               </arguments>
             </configuration>


### PR DESCRIPTION
## Problem

`maven-shade-plugin` was configured to **replace** the main build artifact with the shaded uber jar, so the published `com.testingbot:TestingBotTunnel` Maven artifact was a fat jar bundling Jetty (~1000 classes), Apache HTTP, commons-cli, Jackson, logback, etc.

Maven consumers (notably the [Jenkins TestingBot plugin](https://github.com/jenkinsci/testingbot-plugin)) then received those **bundled classes on a flat classpath**, where they shadow the consumer's own copies. Concretely this:

- breaks the Jenkins plugin's test harness (bundled Jetty 11 clashes with the harness' Jetty 12 — `Request` is a class vs an interface), blocking all `JenkinsRule`/JCasC tests, and
- shadows the consumer's commons-cli (the plugin's modern `DefaultParser`/`Option.builder` threw `NoSuchFieldError` at runtime).

You can't exclude classes bundled inside a jar, so consumers had no way to fix this.

## Change

Attach the shaded uber jar under a **`shaded` classifier** instead of replacing the main artifact:

- **Maven Central** now gets a **thin main jar** (~451 KB, project classes only) whose POM declares the real dependencies, so consumers resolve Jetty/HTTP/commons-cli/etc. **transitively at the correct versions** and can manage/exclude them normally.
- **Docker, the CLI release asset, and the package-time smoke test** use the runnable **`-shaded`** jar, so nothing changes for CLI users.
- The GitHub release keeps the familiar runnable **`TestingBotTunnel-<version>.jar`** download name (the release workflow renames the shaded jar).

No dependency versions changed; this is purely how the artifact is packaged/published.

## Verification

Local `mvn -DskipTests package` (JDK 11):

- `TestingBotTunnel-4.8.jar` — **0 bundled Jetty classes**, 451 KB (thin).
- `TestingBotTunnel-4.8-shaded.jar` — 7.3 MB, runnable: `java -jar target/TestingBotTunnel-4.8-shaded.jar --version` → `Version: testingbot-tunnel.jar 4.8`.

The existing release workflow (tag → `mvn clean deploy` via the Central Portal plugin) publishes the thin main jar + sources + javadoc + the `shaded` classifier, all GPG-signed.

---

## Also: manual "Publish to Maven Central" workflow

Adds `.github/workflows/maven-publish.yml` (`workflow_dispatch`) that deploys the current POM version to Central on demand — deploy only, no GitHub release or Docker. This is how to get **4.8 onto Maven Central** (it's already released on GitHub/Docker but never published to Central), without re-tagging.

⚠️ **Maven Central versions are immutable** — only run this from a branch that builds the thin jar (i.e. this branch, or `master` after merge), so `4.8` is published thin and stays thin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for publishing artifacts to Maven Central.
* **Improvements**
  * Release packages now include the runnable shaded JAR with a consistent filename.
  * Docker builds now use the complete shaded application package.
  * Post-build verification runs against the runnable shaded artifact.
* **Bug Fixes**
  * Corrected release uploads to use the intended executable JAR instead of the thin package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->