### PR TITLE
Keep runtime deps in published POM; auto-publish to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,10 @@
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>
+          <!-- Actually release to Maven Central instead of leaving the deployment in a
+               "pending/validated" state that needs a manual "Publish" click in the portal. -->
+          <autoPublish>true</autoPublish>
+          <waitUntil>published</waitUntil>
         </configuration>
       </plugin>
       <plugin>
@@ -152,6 +156,11 @@
                    The runnable uber jar is attached under the "shaded" classifier for CLI/Docker use. -->
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>shaded</shadedClassifierName>
+              <!-- Keep the real dependencies in the published POM. Because the uber jar is only an
+                   attached artifact (not the main one), the main jar is thin and its consumers must
+                   resolve Jetty/HTTP/commons-cli/etc. transitively; the default dependency-reduced
+                   POM would strip exactly those and leave consumers with unresolvable classes. -->
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <minimizeJar>true</minimizeJar>
               <filters>
                 <filter>


### PR DESCRIPTION
Follow-up to #27. Two fixes to how the Maven artifact is published — both needed before 4.x can be consumed from Maven Central (and the reason 4.8 built green but never appeared there).

## 1. Keep runtime dependencies in the published POM (critical)

#27 attaches the uber jar under the `shaded` classifier and publishes a thin main jar. But `maven-shade-plugin` defaults to `createDependencyReducedPom=true`, which **removes from the published POM every dependency that was shaded into the uber jar** — i.e. Jetty, Apache HTTP, commons-cli, Jackson, logback, jsch, prometheus.

Result: the thin `TestingBotTunnel.jar` published to Central declared **only test-scoped dependencies**, so any consumer got a jar whose runtime classes were unresolvable (`NoClassDefFoundError: org/apache/commons/cli/...`, missing Jetty, etc.).

Fix: `createDependencyReducedPom=false`. Verified locally — the installed POM now declares all runtime deps (jetty-server, jetty-proxy, jetty-servlet, jetty-servlets, httpclient5, commons-cli, jackson-databind, slf4j, logback, jsch, prometheus) while the main jar stays thin (0 bundled Jetty classes).

## 2. Auto-publish to Maven Central

The `central-publishing-maven-plugin` had no `autoPublish`, so it defaults to a **manual** release: `mvn deploy` only uploads a *pending/validated* deployment that then needs a "Publish" click in the Central Portal. That's why the 4.8 publish workflow ran green but 4.8 never showed up on Central.

Fix: `autoPublish=true` + `waitUntil=published`, so a deploy from either the tag-triggered `release.yml` or the manual `Publish to Maven Central` workflow actually releases to Central.

## ⚠️ Note on the pending 4.8 deployment

The 4.8 already uploaded to the Central Portal was built **before** fix #1, so it has the broken dependency-reduced POM. Since Central versions are immutable, please **drop that pending 4.8 deployment** in the portal before publishing. After merging this PR, publish a corrected build (re-run the publish for 4.8 if the pending one is dropped, or tag 4.9) — it will now be both thin *and* have a complete POM, and will publish automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release publishing automation so artifacts are published and verified more reliably.
  * Updated package metadata to accurately reflect dependencies for both standard and runnable distributions.
  * Ensured published artifacts remain compatible with expected dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->