### PR TITLE
Fix the project review's nine findings, and make embedded mode work

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -19,8 +19,33 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # The same gate the tagged release has. Central versions are immutable, so a publish
+  # that skipped the tests cannot be taken back -- and this workflow deploys with
+  # -DskipTests, which means nothing here ran them at all.
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    # -Dgpg.skip: signing belongs to the publish job, which has the key. maven-gpg-plugin
+    # binds to verify, so without this the gate fails on a missing key rather than on a test.
+    - name: Verify
+      run: mvn -B verify -Dgpg.skip=true
+
   publish:
     runs-on: ubuntu-latest
+    needs: test
 
     steps:
     - name: Checkout code

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,7 +24,11 @@ Egress and upstream proxies
 * `--ws-proxy-mode`: how a ws:// upgrade traverses --proxy, `connect` (default, per RFC 6455) or `get`
 * `--connect-to`: dial one host:port for requests naming another, leaving the URL, Host header and TLS SNI untouched
 * `--dns-timeout`, `--dns-round-robin`: per-server timeout and round-robin across the --dns list
-* `--http-dial-timeout`, `--http-idle-timeout`
+* `--http-dial-timeout`, `--http-idle-timeout`. The dial timeout also bounds the SSH control connection, which previously had none: a peer that accepted the socket and sent no banner blocked startup and every reconnect
+* Upstream proxy credentials are scoped to the whole configured endpoint -- protocol, host and port. CONNECT and WebSocket upgrades compared only the hostname, so a PAC file naming 127.0.0.1 on any other port was sent --proxy-userpwd or the SOCKS5 credentials
+* A PAC file is evaluated with the URL the request actually uses, so a rule written on a path is followed by traffic and not only by --pac-test. CONNECT still uses a synthetic https://host:port/, since it carries no path
+* A proxy named only by a PAC file receives absolute-form request targets, and a PAC DIRECT answer sends origin-form even when --proxy is configured
+* The API client authenticates to the upstream proxy with Negotiate when --proxy-auth-scheme negotiate is set. It only ever sent username and password, so on a proxy requiring Kerberos the tunnel could not register at all
 
 Observability
 * `--log-http`: per-request logging at `none`, `url`, `headers` or `errors`, settable per module (`proxy:`, `forwarder:`). `forwarder:body` logs the Selenium relay's request body with credentials redacted by key
@@ -33,11 +37,23 @@ Observability
 * `/healthz` and `/readyz` on the metrics port, and `--ready` to query a running tunnel and exit 0 or 1
 * `--doctor` diagnoses the configuration it was actually given, including the whole Kerberos chain and any --cacert-file subjects
 
+Embedding the tunnel in another application
+* `App.awaitReady(Duration)` and `App.getSetupFailure()`: boot() returns once the tunnel is created, which is not the same as it being able to carry traffic, and a caller had nothing to wait on but its own polling loop
+* Readiness is per tunnel: two tunnels in one JVM each answer for themselves on their own metrics port, where /readyz previously answered from a process-wide gauge for whichever wrote last -- and stopping one reported the other as down
+* stop() restores the JVM's default Authenticator and forgets the SOCKS credentials it registered, so a stopped tunnel's proxy password is no longer offered for the rest of the process's life, and a tunnel per job no longer stacks one authenticator per job
+* The startup self-test asks the API it was configured with rather than naming api.testingbot.com literally, so an embedder pointing at another endpoint is not failed by its own diagnostic
+* The new-version notice is logged rather than written to the host application's stderr
+
 Other
 * `--config`: read options from a file. Every long option also has a TESTINGBOT_* environment alias derived from its name; precedence is command line, then config file, then environment
 * `--header` and `--response-header`: add, replace or remove headers on plain HTTP
 * `--nobump-domains`: disable SSL bumping for named hosts only
-* The tunnel server's SSH host key is verified when the API supplies its fingerprint. Without one the connection is unverified, as before, but says so on every connect and in --doctor
+* `--ssh-host-key`: pin the SHA-256 fingerprint the tunnel server's SSH host key must have. The API's fingerprint is used when it supplies one, and a pin given here outranks it. Without either the connection is unverified, as before, but says so on every connect and in --doctor; `--ssh-host-key-policy require` refuses to connect instead. A fingerprint the API sends that cannot be parsed is now fatal rather than ignored
+* A boolean set to false in a --config file is no longer overridden by the environment. `shared=false` with TESTINGBOT_SHARED=true produced a shared tunnel
+* A failed startup self-test is retried while SSH stays connected, so a check that failed for a transient reason no longer leaves a healthy tunnel reporting 503 forever. The external loopback callback test is skipped, rather than failed, when --localhost-policy deny, --allow-hosts, --fast-fail-regexps, --connect-to or --pac-local would legitimately refuse it, and it now honours --proxy-testingbot and --cacert-file
+* A reconnect reports ready only once both forwarding directions are established; a server that authenticated and then refused the reverse forward used to advertise a tunnel that could carry nothing
+* A queued reconnect no longer fires after shutdown: stop() cancels the reconnect monitor, and every step of a retry checks it
+* Request URLs are redacted in logs -- userinfo and credential-shaped query values -- and TB-Credentials is treated as a sensitive header
 * Example Prometheus + Grafana stack publishes on loopback and requires an admin password to be supplied
 
 4.8

--- a/README.md
+++ b/README.md
@@ -131,6 +131,30 @@ The API key and secret can come from `TESTINGBOT_KEY` / `TESTINGBOT_SECRET` or f
 | `--proxy` | Upstream proxy for egress — browser traffic and, unless `--proxy-testingbot` is set, the tunnel's own connection |
 | `--doctor` | Run diagnostics and exit |
 
+### Verifying the tunnel server
+
+The tunnel's control connection is SSH, and your account secret is its password — so whatever
+answers on the tunnel port receives it. `--ssh-host-key` pins the fingerprint the server must
+present:
+
+```bash
+java -jar testingbot-tunnel.jar --ssh-host-key SHA256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Only SHA-256 fingerprints are accepted (`ssh-keygen -lf <key> -E sha256`); MD5 is refused rather
+than accepted and quietly trusted. Repeat the option, or separate several with commas, when the
+server may present more than one key. The API supplies a fingerprint over its authenticated HTTPS
+connection where it has one, and a pin given here outranks it.
+
+Without a fingerprint from either source the tunnel connects anyway and logs a warning, which is
+the behaviour every existing tunnel has. `--ssh-host-key-policy require` refuses instead:
+
+```bash
+java -jar testingbot-tunnel.jar --ssh-host-key-policy require --ssh-host-key SHA256:...
+```
+
+`--doctor` reports which of these applies before anything connects.
+
 ### Restricting what the tunnel can reach
 
 A tunnel can reach whatever the machine running it can reach. `--fast-fail-regexps` names what to
@@ -293,6 +317,64 @@ has to stream and cannot be buffered for logging.
 
 `--log-format json` writes one JSON object per record, so a collector need not guess where a
 multi-line message or a stack trace ends.
+
+## Embedding it in another application
+
+The tunnel can be run as a library rather than a process. Configure an `App` with the same
+options the command line takes, `boot()` it, and `stop()` it when the work is done:
+
+```java
+App tunnel = new App();
+tunnel.setClientKey(key);
+tunnel.setClientSecret(secret);
+tunnel.setSeleniumPort(4445);
+tunnel.setJettyPort(8087);
+tunnel.setMetricsPort(8003);
+
+try {
+    tunnel.boot();                 // throws TunnelFailedException instead of exiting the JVM
+    if (tunnel.awaitReady(Duration.ofMinutes(2))) {
+        // run the tests
+    } else {
+        throw new IllegalStateException("tunnel not ready: " + tunnel.getSetupFailure());
+    }
+} finally {
+    tunnel.stop();
+}
+```
+
+`boot()` returns once the tunnel has been *created*, which is not the same as it being able to
+carry traffic: when the tunnel server is still starting, the rest happens on a background timer.
+`awaitReady` waits for the state `/readyz` reports and returns false as soon as the setup gives
+up, so a caller does not wait out a timeout for a tunnel that has already failed.
+`isReady()` is the same state without the waiting.
+
+Add the thin jar as a dependency (`com.testingbot:TestingBotTunnel`), not the shaded one — the
+shaded jar bundles relocated copies of Jetty, Apache HttpClient and JSch that will collide with
+your own.
+
+What that guarantees:
+
+* **Nothing calls `System.exit`.** Every failure on the boot path throws `TunnelFailedException`.
+  A failure on a timer thread, where there is nobody to throw to, releases everything and leaves
+  a stopped tunnel whose `isReady()` and `/readyz` say so.
+* **`stop()` gives everything back**: the Selenium relay, the local proxy and the metrics port
+  are unbound, the SSH session and every timer it owns are cancelled, the shutdown hooks are
+  unregistered, the ready file is removed, and the JVM's default `Authenticator` is put back the
+  way it was found. A tunnel per job does not accumulate.
+* **Readiness is per tunnel.** Two tunnels in one process each answer for themselves on their own
+  metrics port.
+* **Logging is left alone.** The console handlers, log levels and `--log-format` wiring are set up
+  by the command line entry point, not by `boot()`.
+
+Three things are process-wide, because the things they are built on are:
+
+* the Prometheus registry behind `/metrics`, and the request/byte counters on `/`, which
+  aggregate across tunnels in the same JVM;
+* `Authenticator.setDefault`, which the JDK offers no per-connection alternative to for proxy and
+  SOCKS credentials. The tunnel's authenticator answers only for the proxy it was given and
+  delegates everything else to whatever was installed before it;
+* uptime, which is measured from the first tunnel to boot.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ traffic to TestingBot and routes the browser's web requests back through your ne
 > **Running tunnel 4.x or older?** This page documents **5.0**, which needs Java 17 and changes
 > a few defaults. The 4.x source and its documentation stay on the
 > [`v4.x` branch](https://github.com/testingbot/Testingbot-Tunnel/tree/v4.x). If you are upgrading, read
-> [Upgrading from 4.x](#upgrading-from-4x) first — it is short, and two of the changes are
-> ones you will notice immediately.
+> [Upgrading from 4.x](docs/upgrading-from-4x.md) first — it is short, and existing command lines
+> keep working, but the listeners now bind loopback and successful requests no longer log.
 
 ## Requirements
 
@@ -20,39 +20,6 @@ traffic to TestingBot and routes the browser's web requests back through your ne
 | **5.0** and later | **17** | Built on Jetty 12. Tested on 17, 21 and 25. |
 | 4.x | 11 | Jetty 11, which is end-of-life and no longer receives security fixes. |
 | 3.x and earlier | 8 | Unsupported. |
-
-## Upgrading from 4.x
-
-5.0 adds 28 options and removes none, so existing command lines keep working. Six things do
-change, and the first three are the ones people notice:
-
-| | 4.x | 5.0 | To keep the 4.x behaviour |
-|---|---|---|---|
-| **Java** | 11 | **17** | — (hard requirement) |
-| **What the listeners bind** | every interface | `127.0.0.1` | `--bind-address 0.0.0.0` |
-| **Per-request logging** | one `INFO` line per request | only failures and 5xx | `--log-http url` |
-| **Selenium relay logging** | always logged | honours `--log-http` | `--log-http forwarder:url` |
-| **Docker image** | — | sets `TESTINGBOT_BIND_ADDRESS=0.0.0.0` | — (published ports keep working) |
-| **Embedding the jar** | Jetty 11 + Servlet API | Jetty 12 core handlers | — (source change) |
-
-**Java 17.** The jar's classes cannot be loaded by an older JVM. The tunnel checks the version
-itself and says so plainly, rather than failing as `A JNI error has occurred`.
-
-**Listeners bind loopback.** In 4.x the Selenium relay (`4445`), the local proxy (`8087`), the
-insight endpoints (`8003`) and `--web` (`8080`) accepted connections from any machine that could
-route to yours. None of them authenticates: the relay attaches your TestingBot key and secret to
-everything it forwards, and the proxy will connect anywhere your machine can, including its own
-loopback. They now bind `127.0.0.1`.
-
-If your tests run on the same machine as the tunnel — the normal case — nothing changes. If they
-run elsewhere, add `--bind-address 0.0.0.0` and restrict the port with a firewall. The Docker
-image sets that for you, because a loopback bind inside a container makes published ports
-unreachable; narrow it there on the host side of the publish instead
-(`-p 127.0.0.1:4445:4445`).
-
-**Quieter logs.** 4.x logged a line for every proxied request. 5.0 logs failures and 5xx only.
-`--log-http url` restores a line per request, and `--log-http` takes a level per module —
-`--log-http proxy:url,forwarder:none`.
 
 ## Getting started
 
@@ -100,9 +67,8 @@ TESTINGBOT_SE_PORT=4446 java -jar testingbot-tunnel.jar
 
 ### Keeping credentials out of the process list
 
-Anything on the command line is visible to other users of the machine in `ps`. Every long option
-has a `TESTINGBOT_*` alias derived from its name, so the ones carrying a secret can be set in the
-environment instead:
+Anything on the command line is visible to other users of the machine in `ps`, so the options
+carrying a secret are worth setting in the environment instead:
 
 | Option | Environment variable | Format |
 |---|---|---|
@@ -111,12 +77,9 @@ environment instead:
 | `--proxy-testingbot-userpwd` | `TESTINGBOT_PROXY_TESTINGBOT_USERPWD` | `user:password` |
 | `--metrics-auth` | `TESTINGBOT_METRICS_AUTH` | `user:password` |
 
-The API key and secret can come from `TESTINGBOT_KEY` / `TESTINGBOT_SECRET` or from
-`~/.testingbot` instead of being passed as arguments. The flag always wins over the variable.
-
-> The positional `API_KEY API_SECRET` form shown above is still supported, but it does put the
-> secret in `ps` for as long as the tunnel runs. On a shared machine, prefer the environment
-> variables or `~/.testingbot`.
+> The positional `API_KEY API_SECRET` form is still supported, but it puts the secret in `ps` for
+> as long as the tunnel runs. On a shared machine, prefer `TESTINGBOT_KEY` / `TESTINGBOT_SECRET`
+> or `~/.testingbot`. A flag always wins over the matching variable.
 
 `--help` lists everything. The options people reach for most:
 
@@ -133,27 +96,20 @@ The API key and secret can come from `TESTINGBOT_KEY` / `TESTINGBOT_SECRET` or f
 
 ### Verifying the tunnel server
 
-The tunnel's control connection is SSH, and your account secret is its password — so whatever
+The tunnel's control connection is SSH and your account secret is its password, so whatever
 answers on the tunnel port receives it. `--ssh-host-key` pins the fingerprint the server must
-present:
+present, and `--ssh-host-key-policy require` refuses to connect without one:
 
 ```bash
-java -jar testingbot-tunnel.jar --ssh-host-key SHA256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+java -jar testingbot-tunnel.jar --ssh-host-key SHA256:xxxx... --ssh-host-key-policy require
 ```
 
-Only SHA-256 fingerprints are accepted (`ssh-keygen -lf <key> -E sha256`); MD5 is refused rather
-than accepted and quietly trusted. Repeat the option, or separate several with commas, when the
-server may present more than one key. The API supplies a fingerprint over its authenticated HTTPS
-connection where it has one, and a pin given here outranks it.
-
-Without a fingerprint from either source the tunnel connects anyway and logs a warning, which is
-the behaviour every existing tunnel has. `--ssh-host-key-policy require` refuses instead:
-
-```bash
-java -jar testingbot-tunnel.jar --ssh-host-key-policy require --ssh-host-key SHA256:...
-```
-
-`--doctor` reports which of these applies before anything connects.
+Only SHA-256 is accepted (`ssh-keygen -lf <key> -E sha256`); MD5 is collidable, so it is refused
+rather than quietly trusted. Repeat the option, or comma-separate several, where the server may
+present more than one key. The API supplies a fingerprint over its authenticated HTTPS connection
+where it has one, and a pin given here outranks it. Without either the tunnel connects anyway and
+logs a warning, which is what every existing tunnel does. `--doctor` reports which case applies
+before anything connects.
 
 ### Restricting what the tunnel can reach
 
@@ -241,13 +197,13 @@ Use `https://` or a local file where you can. Redirects are refused rather than 
 what is fetched is what you named.
 
 The file is evaluated by a restricted interpreter built for this purpose — **no JavaScript
-engine is embedded**. That keeps the dependency surface small for a process that already sits in
-the network path, at the cost of supporting only the subset PAC files actually use: functions,
-variables, conditionals, loops, the usual operators, and the standard helpers (`isPlainHostName`,
-`dnsDomainIs`, `shExpMatch`, `isInNet`, `dnsResolve`, `myIpAddress`, `weekdayRange`, `dateRange`,
-`timeRange` and friends). Anything outside it — object literals, regular expressions, `new` — is
-**reported with its line number rather than guessed at**, because a misread PAC file silently
-sends traffic to the wrong place.
+engine is embedded**. That keeps the dependency surface small for a process already sitting in
+the network path, at the cost of supporting only the subset PAC files use: functions, variables,
+conditionals, loops, the usual operators, and the standard helpers (`isPlainHostName`,
+`dnsDomainIs`, `shExpMatch`, `isInNet`, `dnsResolve`, `myIpAddress` and the date/time
+predicates). Anything outside it — object literals, regular expressions, `new` — is **reported
+with its line number rather than guessed at**, because a misread PAC file silently sends traffic
+to the wrong place.
 
 Check a file before relying on it:
 
@@ -320,61 +276,12 @@ multi-line message or a stack trace ends.
 
 ## Embedding it in another application
 
-The tunnel can be run as a library rather than a process. Configure an `App` with the same
-options the command line takes, `boot()` it, and `stop()` it when the work is done:
+The tunnel runs as a library as well as a process: configure an `App`, `boot()` it, wait on
+`awaitReady(Duration)`, and `stop()` it when the work is done. Nothing calls `System.exit`,
+`stop()` gives every port, thread and hook back, and two tunnels in one JVM report their
+readiness separately.
 
-```java
-App tunnel = new App();
-tunnel.setClientKey(key);
-tunnel.setClientSecret(secret);
-tunnel.setSeleniumPort(4445);
-tunnel.setJettyPort(8087);
-tunnel.setMetricsPort(8003);
-
-try {
-    tunnel.boot();                 // throws TunnelFailedException instead of exiting the JVM
-    if (tunnel.awaitReady(Duration.ofMinutes(2))) {
-        // run the tests
-    } else {
-        throw new IllegalStateException("tunnel not ready: " + tunnel.getSetupFailure());
-    }
-} finally {
-    tunnel.stop();
-}
-```
-
-`boot()` returns once the tunnel has been *created*, which is not the same as it being able to
-carry traffic: when the tunnel server is still starting, the rest happens on a background timer.
-`awaitReady` waits for the state `/readyz` reports and returns false as soon as the setup gives
-up, so a caller does not wait out a timeout for a tunnel that has already failed.
-`isReady()` is the same state without the waiting.
-
-Add the thin jar as a dependency (`com.testingbot:TestingBotTunnel`), not the shaded one — the
-shaded jar bundles relocated copies of Jetty, Apache HttpClient and JSch that will collide with
-your own.
-
-What that guarantees:
-
-* **Nothing calls `System.exit`.** Every failure on the boot path throws `TunnelFailedException`.
-  A failure on a timer thread, where there is nobody to throw to, releases everything and leaves
-  a stopped tunnel whose `isReady()` and `/readyz` say so.
-* **`stop()` gives everything back**: the Selenium relay, the local proxy and the metrics port
-  are unbound, the SSH session and every timer it owns are cancelled, the shutdown hooks are
-  unregistered, the ready file is removed, and the JVM's default `Authenticator` is put back the
-  way it was found. A tunnel per job does not accumulate.
-* **Readiness is per tunnel.** Two tunnels in one process each answer for themselves on their own
-  metrics port.
-* **Logging is left alone.** The console handlers, log levels and `--log-format` wiring are set up
-  by the command line entry point, not by `boot()`.
-
-Three things are process-wide, because the things they are built on are:
-
-* the Prometheus registry behind `/metrics`, and the request/byte counters on `/`, which
-  aggregate across tunnels in the same JVM;
-* `Authenticator.setDefault`, which the JDK offers no per-connection alternative to for proxy and
-  SOCKS credentials. The tunnel's authenticator answers only for the proxy it was given and
-  delegates everything else to whatever was installed before it;
-* uptime, which is measured from the first tunnel to boot.
+See [docs/embedding.md](docs/embedding.md) for the worked example and what is guaranteed.
 
 ## Building
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,0 +1,57 @@
+# Embedding the tunnel in another application
+
+The tunnel can be run as a library rather than a process. Configure an `App` with the same
+options the command line takes, `boot()` it, and `stop()` it when the work is done:
+
+```java
+App tunnel = new App();
+tunnel.setClientKey(key);
+tunnel.setClientSecret(secret);
+tunnel.setSeleniumPort(4445);
+tunnel.setJettyPort(8087);
+tunnel.setMetricsPort(8003);
+
+try {
+    tunnel.boot();                 // throws TunnelFailedException instead of exiting the JVM
+    if (tunnel.awaitReady(Duration.ofMinutes(2))) {
+        // run the tests
+    } else {
+        throw new IllegalStateException("tunnel not ready: " + tunnel.getSetupFailure());
+    }
+} finally {
+    tunnel.stop();
+}
+```
+
+`boot()` returns once the tunnel has been *created*, which is not the same as it being able to
+carry traffic: when the tunnel server is still starting, the rest happens on a background timer.
+`awaitReady` waits for the state `/readyz` reports and returns false as soon as the setup gives
+up, so a caller does not wait out a timeout for a tunnel that has already failed.
+`isReady()` is the same state without the waiting.
+
+Add the thin jar as a dependency (`com.testingbot:TestingBotTunnel`), not the shaded one — the
+shaded jar bundles relocated copies of Jetty, Apache HttpClient and JSch that will collide with
+your own.
+
+What that guarantees:
+
+* **Nothing calls `System.exit`.** Every failure on the boot path throws `TunnelFailedException`.
+  A failure on a timer thread, where there is nobody to throw to, releases everything and leaves
+  a stopped tunnel whose `isReady()` and `/readyz` say so.
+* **`stop()` gives everything back**: the Selenium relay, the local proxy and the metrics port
+  are unbound, the SSH session and every timer it owns are cancelled, the shutdown hooks are
+  unregistered, the ready file is removed, and the JVM's default `Authenticator` is put back the
+  way it was found. A tunnel per job does not accumulate.
+* **Readiness is per tunnel.** Two tunnels in one process each answer for themselves on their own
+  metrics port.
+* **Logging is left alone.** The console handlers, log levels and `--log-format` wiring are set up
+  by the command line entry point, not by `boot()`.
+
+Three things are process-wide, because the things they are built on are:
+
+* the Prometheus registry behind `/metrics`, and the request/byte counters on `/`, which
+  aggregate across tunnels in the same JVM;
+* `Authenticator.setDefault`, which the JDK offers no per-connection alternative to for proxy and
+  SOCKS credentials. The tunnel's authenticator answers only for the proxy it was given and
+  delegates everything else to whatever was installed before it;
+* uptime, which is measured from the first tunnel to boot.

--- a/docs/upgrading-from-4x.md
+++ b/docs/upgrading-from-4x.md
@@ -1,0 +1,32 @@
+# Upgrading from 4.x
+
+5.0 adds 28 options and removes none, so existing command lines keep working. Six things do
+change, and the first three are the ones people notice:
+
+| | 4.x | 5.0 | To keep the 4.x behaviour |
+|---|---|---|---|
+| **Java** | 11 | **17** | — (hard requirement) |
+| **What the listeners bind** | every interface | `127.0.0.1` | `--bind-address 0.0.0.0` |
+| **Per-request logging** | one `INFO` line per request | only failures and 5xx | `--log-http url` |
+| **Selenium relay logging** | always logged | honours `--log-http` | `--log-http forwarder:url` |
+| **Docker image** | — | sets `TESTINGBOT_BIND_ADDRESS=0.0.0.0` | — (published ports keep working) |
+| **Embedding the jar** | Jetty 11 + Servlet API | Jetty 12 core handlers | — (source change) |
+
+**Java 17.** The jar's classes cannot be loaded by an older JVM. The tunnel checks the version
+itself and says so plainly, rather than failing as `A JNI error has occurred`.
+
+**Listeners bind loopback.** In 4.x the Selenium relay (`4445`), the local proxy (`8087`), the
+insight endpoints (`8003`) and `--web` (`8080`) accepted connections from any machine that could
+route to yours. None of them authenticates: the relay attaches your TestingBot key and secret to
+everything it forwards, and the proxy will connect anywhere your machine can, including its own
+loopback. They now bind `127.0.0.1`.
+
+If your tests run on the same machine as the tunnel — the normal case — nothing changes. If they
+run elsewhere, add `--bind-address 0.0.0.0` and restrict the port with a firewall. The Docker
+image sets that for you, because a loopback bind inside a container makes published ports
+unreachable; narrow it there on the host side of the publish instead
+(`-p 127.0.0.1:4445:4445`).
+
+**Quieter logs.** 4.x logged a line for every proxied request. 5.0 logs failures and 5xx only.
+`--log-http url` restores a line per request, and `--log-http` takes a level per module —
+`--log-http proxy:url,forwarder:none`.

--- a/src/main/java/com/testingbot/tunnel/Api.java
+++ b/src/main/java/com/testingbot/tunnel/Api.java
@@ -34,6 +34,8 @@ import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.apache.hc.core5.util.Timeout;
 
 import com.testingbot.tunnel.proxy.ProxySpec;
+import com.testingbot.tunnel.proxy.ProxyAuthenticator;
+import com.testingbot.tunnel.proxy.ProxyNegotiateScheme;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -137,7 +139,15 @@ public class Api {
         if (spec.isSocks5()) {
             configureSocksProxy(builder, spec, credentials);
         } else {
-            if (credentials != null) {
+            if (ProxyAuthenticator.Scheme.parse(app.getProxyAuthScheme())
+                    == ProxyAuthenticator.Scheme.NEGOTIATE) {
+                ProxyAuthenticator authenticator = app.controlProxyAuthenticator();
+                // Proxy authentication also runs for HttpClient's internally generated HTTPS
+                // CONNECT requests. A request interceptor would miss those requests.
+                builder.setProxyAuthenticationStrategy((type, challenges, context) ->
+                        challenges.containsKey("negotiate")
+                                ? List.of(new ProxyNegotiateScheme(spec, authenticator)) : List.of());
+            } else if (credentials != null) {
                 BasicCredentialsProvider credsProvider = new BasicCredentialsProvider();
                 credsProvider.setCredentials(
                     new AuthScope(spec.getHost(), spec.getPort()),
@@ -269,6 +279,21 @@ public class Api {
         Authenticator.setDefault(installedAuthenticator);
     }
 
+    /**
+     * Forgets the SOCKS credentials for one proxy endpoint.
+     *
+     * <p>The registry is static, so without this a stopped tunnel's password went on being
+     * offered for the proxy it named -- to the host application's own SOCKS connections, in an
+     * embedded process, for as long as the JVM lived. The authenticator itself stays installed
+     * and delegating: something else may have chained to it since, and an empty registry makes
+     * it a pass-through.
+     */
+    static void forgetSocksCredentials(ProxySpec spec) {
+        if (spec != null) {
+            SOCKS_CREDENTIALS.remove(key(spec.getHost(), spec.getPort()));
+        }
+    }
+
     private static String key(String host, int port) {
         return (host == null ? "" : host.toLowerCase(java.util.Locale.ROOT)) + ":" + port;
     }
@@ -312,6 +337,21 @@ public class Api {
     }
 
     /**
+     * The absolute URL of an API path, as this Api is configured to reach it.
+     *
+     * <p>Everything that talks to the API has to go through here. The startup self-test built
+     * {@code https://api.testingbot.com/...} literally, so an embedder that pointed its Api
+     * somewhere else -- the only way to run this against anything but production -- had two of
+     * its three readiness checks agreeing with the configuration and the third talking to a host
+     * it was told not to use. Readiness is gated on that check, so it failed the whole tunnel.
+     *
+     * @param path the path, beginning with a slash
+     */
+    String url(String path) {
+        return apiScheme + "://" + apiHost + path;
+    }
+
+    /**
      * For testing purposes only - allows providing a custom HttpClientBuilder
      */
     void setHttpClientBuilderSupplier(Supplier<HttpClientBuilder> supplier) {
@@ -338,7 +378,7 @@ public class Api {
                 nameValuePairs.add(new BasicNameValuePair("no_bump_domains", noBumpDomains));
             }
             nameValuePairs.add(new BasicNameValuePair("shared", String.valueOf(app.isShared())));
-            return this._post(apiScheme + "://" + apiHost + "/v1/tunnel/create", nameValuePairs);
+            return this._post(url("/v1/tunnel/create"), nameValuePairs);
         }
         catch (Exception e) {
             throw new Exception("Could not start tunnel: " + describe(e));
@@ -371,7 +411,7 @@ public class Api {
 
     public JsonNode pollTunnel(String tunnelID) throws Exception {
         try {
-            return this._get(apiScheme + "://" + apiHost + "/v1/tunnel/" + tunnelID);
+            return this._get(url("/v1/tunnel/" + tunnelID));
         }
         catch (Exception e) {
             throw new Exception("Could not get tunnel info: " + e.getMessage());
@@ -385,7 +425,7 @@ public class Api {
             String auth = this.clientKey + ":" + this.clientSecret;
             String encoding = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
 
-            HttpDelete deleteRequest = new HttpDelete(apiScheme + "://" + apiHost + "/v1/tunnel/" + this.tunnelID);
+            HttpDelete deleteRequest = new HttpDelete(url("/v1/tunnel/" + this.tunnelID));
             deleteRequest.addHeader("accept", "application/json");
             deleteRequest.setHeader("Authorization", "Basic " + encoding);
 

--- a/src/main/java/com/testingbot/tunnel/App.java
+++ b/src/main/java/com/testingbot/tunnel/App.java
@@ -16,6 +16,8 @@ import java.net.ServerSocket;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
@@ -128,6 +130,16 @@ public class App {
      * be replaced by a later API-supplied one, while a pin a caller set is never overwritten.
      */
     private boolean sshHostKeyPinsFromApi;
+    /**
+     * What to do when nothing can verify the tunnel server: "warn" (default) or "require".
+     *
+     * <p>Not "require" by default because the service does not publish fingerprints for every
+     * tunnel server yet, and defaulting to it would refuse connections that work today. It is
+     * the setting to use on a network where an intermediary could answer for the tunnel server.
+     */
+    private String sshHostKeyPolicy = HOST_KEY_POLICY_WARN;
+    static final String HOST_KEY_POLICY_WARN = "warn";
+    static final String HOST_KEY_POLICY_REQUIRE = "require";
     private int sshPort = 0;
     private boolean shared = false;
 
@@ -438,6 +450,23 @@ public class App {
         // customer's API key back at them -- the line that gets pasted into a support
         // ticket. Repeating the option already yields every occurrence.
         options.addOption(caCert);
+
+        Option sshHostKey = new Option(null, "ssh-host-key", true,
+            "SHA-256 fingerprint the tunnel server's SSH host key must have, as printed by "
+            + "ssh-keygen -lf <key> -E sha256. Repeatable, and a single value may list several "
+            + "separated by commas. The account secret is the SSH password, so without a "
+            + "fingerprint -- from here or from the API -- whatever answers on the tunnel port "
+            + "receives it. A pin given here outranks the one the API supplies.");
+        sshHostKey.setArgName("SHA256:...");
+        options.addOption(sshHostKey);
+
+        Option sshHostKeyPolicy = new Option(null, "ssh-host-key-policy", true,
+            "What to do when no host key fingerprint is available: warn (default) connects "
+            + "anyway and says so, require refuses to connect. Requiring one is the safe "
+            + "setting and will become the default once the service publishes fingerprints for "
+            + "every tunnel server; until then it is opt-in so existing tunnels keep working.");
+        sshHostKeyPolicy.setArgName("warn|require");
+        options.addOption(sshHostKeyPolicy);
 
         Option controlProxy = new Option(null, "proxy-testingbot", true,
             "Upstream proxy for reaching TestingBot itself -- the API and the SSH control "
@@ -864,7 +893,7 @@ public class App {
             // Config entries first, then the environment for anything still unset, so the
             // parser below sees all three sources as if they had been typed on the command line.
             commandLine = cmdLinePosixParser.parse(options,
-                    EnvOptions.expand(ConfigFile.expand(args, options), options));
+                    EnvOptions.expand(ConfigFile.expandWithSources(args, options), options));
             if (commandLine.hasOption("help")) {
                 HelpFormatter help = new HelpFormatter();
                 help.setWidth(180);
@@ -1076,6 +1105,24 @@ public class App {
     private static volatile String activeLogFormat = "text";
     /** The --web directory server, or null when --web was not given. */
     private LocalWebServer localWebServer;
+    /**
+     * Whether *this* tunnel is forwarding.
+     *
+     * <p>Per App, not static. `/readyz` used to answer from the process-wide gauge, so a host
+     * application running two tunnels -- or one per job, overlapping -- had both endpoints
+     * answering for whichever App wrote last, and stopping one reported the other as not ready.
+     * The gauge is still kept in step for the single-tunnel case, which is every command line
+     * run; it is process-wide by nature, since the Prometheus registry is.
+     */
+    private volatile boolean ready;
+
+    /** Why a tunnel that will not come up gave up, or null while it may still succeed. */
+    private volatile String setupFailure;
+
+    /** Our JVM-wide proxy authenticator and what it replaced, so {@link #stop} can undo it. */
+    private Authenticator installedProxyAuthenticator;
+    private Authenticator previousDefaultAuthenticator;
+
     private PidPoller pidPoller;
     private TunnelPoller poller;
     private HttpForwarder httpForwarder;
@@ -1115,7 +1162,7 @@ public class App {
                 if (tunnel != null) {
                     tunnel.stop();
                 }
-                TunnelMetrics.setTunnelUp(false);
+                setReady(false);
                 try {
                     Logger.getLogger(App.class.getName()).log(Level.INFO,
                             "Shutting down your personal Tunnel Server.");
@@ -1133,6 +1180,15 @@ public class App {
         return new Api(this);
     }
 
+    /**
+     * Package-private for the same reason as {@link #createApi}: the tunnel server's port and the
+     * hub host are fixed in production, so without a seam nothing that boots a whole App can run
+     * anywhere but against the live service.
+     */
+    ssh.SSHTunnel createTunnel(String serverIp) throws Exception {
+        return new ssh.SSHTunnel(this, serverIp);
+    }
+
     public void boot() throws Exception {
         // Set here, not only in main(): an embedder constructs App directly, leaving startTime at
         // zero, so uptime was reported as seconds since the epoch -- a number that keeps climbing
@@ -1141,6 +1197,7 @@ public class App {
             Statistics.setStartTime(System.currentTimeMillis());
         }
 
+        setupFailure = null;
         api = createApi();
         JsonNode tunnelData = null;
 
@@ -1173,7 +1230,12 @@ public class App {
         // unexpected value from the API would have thrown out of boot() entirely.
         Version latest = Version.parse(tunnelData.path("version").asText(null));
         if (latest != null && RELEASE != null && RELEASE.isOlderThan(latest)) {
-            System.err.println("A new version (" + latest + ") is available for download at https://testingbot.com\nYou have version " + App.VERSION);
+            // Logged, not printed: boot() runs inside whatever process embeds this, and a
+            // library writing to the host application's stderr is noise it cannot switch off.
+            // The command line client's console handler puts it on the terminal as before.
+            Logger.getLogger(App.class.getName()).log(Level.INFO,
+                    "A new version ({0}) is available for download at https://testingbot.com. "
+                            + "You have version {1}.", new Object[]{latest, App.VERSION});
         }
 
         Logger.getLogger(App.class.getName()).log(Level.INFO, "Please wait while your personal Tunnel Server is being setup. Shouldn't take more than a minute.\nWhen the tunnel is ready you will see a message \"You may start your tests.\"");
@@ -1216,6 +1278,7 @@ public class App {
      */
     public void setupFailed(String reason, int exitCode) {
         Logger.getLogger(App.class.getName()).log(Level.SEVERE, reason);
+        this.setupFailure = reason;
         try {
             stop();
         } catch (Exception cleanupFailed) {
@@ -1224,7 +1287,7 @@ public class App {
         }
         // After stop(), which sets it false itself -- but stop() is also the ordinary teardown,
         // so being explicit here keeps the reason for the gauge attached to this path.
-        TunnelMetrics.setTunnelUp(false);
+        setReady(false);
         if (commandLineClient) {
             // Already logged above; printing it again would duplicate it under text and break
             // the stream under json.
@@ -1236,7 +1299,8 @@ public class App {
     }
 
     public void stop() {
-        TunnelMetrics.setTunnelUp(false);
+        setReady(false);
+        cancelSelfTestRetry();
 
         if (tunnel != null) {
             tunnel.stop(true);
@@ -1284,6 +1348,10 @@ public class App {
             }
         }
 
+        restoreDefaultAuthenticator();
+        Api.forgetSocksCredentials(
+                com.testingbot.tunnel.proxy.ProxySpec.parse(getControlProxy()));
+
         // Without this, an embedder that starts a tunnel per job leaks one
         // shutdown hook per App instance for the lifetime of the JVM.
         if (cleanupThread != null) {
@@ -1317,12 +1385,12 @@ public class App {
             // describes the server about to be dialled. Adopting only in boot() left every
             // polled tunnel unverified.
             adoptApiHostKeyFingerprint(apiResponse);
-            tunnel = new SSHTunnel(this, _serverIP);
+            tunnel = createTunnel(_serverIP);
             if (tunnel.isAuthenticated()) {
                 this.serverIP = _serverIP;
                 Logger.getLogger(App.class.getName()).log(Level.INFO, "Successfully authenticated, setting up forwarding.");
                 tunnel.createPortForwarding();
-                boolean healthy = this.startProxies();
+                boolean healthy = this.startProxies() && tunnel.isForwardingEstablished();
                 // Gated on the self-test, not merely on having got this far. /readyz means "the
                 // tunnel is forwarding", and every check startProxies() runs is a check that
                 // traffic will actually arrive -- the Selenium relay reaching the hub, the
@@ -1330,12 +1398,13 @@ public class App {
                 // tunnel that failed one of those carries nothing, so reporting it ready told
                 // container probes and --readyfile integrations to send work to something that
                 // could not do any. It stays not-ready until a reconnect succeeds.
-                TunnelMetrics.setTunnelUp(healthy);
+                setReady(healthy);
                 if (healthy) {
                     writeReadyFile();
                     Logger.getLogger(App.class.getName()).log(Level.INFO, "The Tunnel is ready, ip: {0}\nYou may start your tests.", _serverIP);
                 } else {
                     Logger.getLogger(App.class.getName()).log(Level.SEVERE, "The Tunnel is up (ip: {0}) but its self-test failed, so it is not reporting ready; tests will not work until this is resolved.", _serverIP);
+                    scheduleSelfTestRetry();
                 }
                 Logger.getLogger(App.class.getName()).log(Level.INFO, "To stop the tunnel, press CTRL+C");
             }
@@ -1351,15 +1420,92 @@ public class App {
         }
     }
 
+    /**
+     * Puts back whatever {@code Authenticator.getDefault()} was before {@code --proxy-userpwd}.
+     *
+     * <p>{@code Authenticator.setDefault} is JVM-wide and there is no other hook for the JDK's
+     * proxy authentication, so a tunnel embedded in a host application installs something that
+     * outlives it. Left in place, a stopped tunnel's credentials went on being offered for the
+     * proxy it named, and a host starting a tunnel per job stacked one delegating authenticator
+     * per job for the life of the process.
+     *
+     * <p>Only when ours is still the default: if something else installed one afterwards, it has
+     * ours in its chain and removing it here would break that instead.
+     */
+    private void restoreDefaultAuthenticator() {
+        if (installedProxyAuthenticator == null) {
+            return;
+        }
+        if (Authenticator.getDefault() == installedProxyAuthenticator) {
+            Authenticator.setDefault(previousDefaultAuthenticator);
+        }
+        installedProxyAuthenticator = null;
+        previousDefaultAuthenticator = null;
+    }
+
+    /**
+     * Blocks until this tunnel is forwarding, it gives up, or the timeout expires.
+     *
+     * <p>For embedders. {@code boot()} returns as soon as the tunnel has been *created*, and when
+     * the server was not yet READY the rest happens on the poller's timer thread -- so a caller
+     * that started running tests when {@code boot()} returned was racing the tunnel it had just
+     * asked for. Polling is enough here: readiness changes once, and a caller that wants to know
+     * the instant it does can read {@link #isReady()} itself.
+     *
+     * @param timeout how long to wait
+     * @return true if the tunnel became ready, false on a timeout or a failed setup
+     * @throws InterruptedException if the calling thread is interrupted while waiting
+     */
+    public boolean awaitReady(java.time.Duration timeout) throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (true) {
+            if (ready) {
+                return true;
+            }
+            if (setupFailure != null) {
+                // Terminal: nothing is still trying, so waiting out the clock would only delay
+                // the caller's own error handling.
+                return false;
+            }
+            if (System.nanoTime() >= deadline) {
+                return false;
+            }
+            Thread.sleep(50);
+        }
+    }
+
+    /**
+     * @return why the tunnel gave up, or null if it has not -- for an embedder that wants the
+     *         reason rather than the log line {@link #setupFailed} writes
+     */
+    public String getSetupFailure() {
+        return setupFailure;
+    }
+
+    /**
+     * @return true when this tunnel is forwarding, which is what {@code /readyz} answers
+     */
+    public boolean isReady() {
+        return ready;
+    }
+
+    /**
+     * Records readiness for this App and mirrors it to the process-wide gauge.
+     *
+     * <p>Public because the reconnect monitor lives in another package and reports through
+     * {@link ssh.ReconnectHost}; it is not part of what an embedder is expected to call. The
+     * gauge stays in step because a single-tunnel process -- every command line run -- is what
+     * {@code tunnel_up} describes. With two tunnels in one JVM the gauge is whichever wrote
+     * last, while {@code /readyz} on each metrics port answers for its own App.
+     */
+    public void setReady(boolean ready) {
+        this.ready = ready;
+        TunnelMetrics.setTunnelUp(ready);
+    }
+
     /** Package-private so ReadinessGatingTest can drive a failing startup. */
     boolean startProxies() {
-        boolean healthy = true;
         httpForwarder = new HttpForwarder(this);
-
-        if (!httpForwarder.testForwarding()) {
-            Logger.getLogger(App.class.getName()).log(Level.SEVERE, "! Forwarder testing failed, localhost port {0} does not seem to be able to reach our hub (hub.testingbot.com)", Integer.toString(getSeleniumPort()));
-            healthy = false;
-        }
 
         if (!this.noProxy) {
             try {
@@ -1367,17 +1513,124 @@ public class App {
             } catch (HttpProxy.HttpProxyStartException ex) {
                 throw new TunnelFailedException(ex.getMessage(), 1, ex);
             }
+        }
+
+        return selfTest();
+    }
+
+    /**
+     * The startup self-test, separated from building the listeners so it can be repeated.
+     *
+     * <p>Each check is a check that traffic will actually arrive. They can fail for reasons that
+     * pass a moment later -- the hub refusing a connection while the tunnel server finishes
+     * booting, say -- and a single such failure used to leave a connected tunnel reporting 503 for
+     * as long as SSH stayed up, with nothing retrying it. {@link #scheduleSelfTestRetry} is what
+     * resolves that; this method is the part worth repeating.
+     */
+    boolean selfTest() {
+        boolean healthy = true;
+
+        if (!httpForwarder.testForwarding()) {
+            Logger.getLogger(App.class.getName()).log(Level.SEVERE, "! Forwarder testing failed, localhost port {0} does not seem to be able to reach our hub (hub.testingbot.com)", Integer.toString(getSeleniumPort()));
+            healthy = false;
+        }
+
+        if (!this.noProxy && this.httpProxy != null) {
             if (tunnel != null && !tunnel.verifyReverseForwardDelivery()) {
                 Logger.getLogger(App.class.getName()).log(Level.SEVERE, "! Reverse port forwarding cannot reach the local proxy on port {0}, traffic through the tunnel will fail", Integer.toString(getJettyPort()));
                 healthy = false;
             }
-            if (this.getProxy() == null && !this.httpProxy.testProxy()) {
+            if (!shouldRunProxyCallbackTest()) {
+                Logger.getLogger(App.class.getName()).log(Level.INFO,
+                        "Skipping external loopback callback test because destination policy or routing is configured; local forwarding checks still apply.");
+            } else if (!this.httpProxy.testProxy()) {
                 Logger.getLogger(App.class.getName()).log(Level.SEVERE, "! Tunnel might not work properly, test failed");
                 healthy = false;
             }
         }
 
         return healthy;
+    }
+
+    /** How long between self-test retries, and how many are attempted before giving up. */
+    static final long SELF_TEST_RETRY_INTERVAL_MS = 30_000L;
+    static final int SELF_TEST_RETRY_ATTEMPTS = 10;
+
+    private Timer selfTestRetryTimer;
+    /** Package-private so a test does not have to wait the production interval. */
+    long selfTestRetryIntervalMs = SELF_TEST_RETRY_INTERVAL_MS;
+
+    /** Package-private so a test can drive the retry without a live SSH session. */
+    boolean tunnelIsForwarding() {
+        return tunnel != null && tunnel.isForwardingEstablished();
+    }
+
+    /**
+     * Re-runs {@link #selfTest} while SSH stays connected, until it passes or the attempts run
+     * out.
+     *
+     * <p>Readiness is gated on the self-test, so a transient failure at startup -- the hub not
+     * yet accepting connections on a tunnel server that has only just booted -- otherwise
+     * pinned this process at 503 forever, with a working SSH session and nothing that would
+     * ever look again. Reconnects already re-run the whole sequence; this covers the case where
+     * the connection never drops.
+     */
+    synchronized void scheduleSelfTestRetry() {
+        if (selfTestRetryTimer != null) {
+            return;
+        }
+        Timer timer = new Timer("SelfTestRetry-" + getJettyPort(), true);
+        selfTestRetryTimer = timer;
+        timer.schedule(new TimerTask() {
+            private int attempts;
+
+            @Override
+            public void run() {
+                attempts += 1;
+                if (!tunnelIsForwarding()) {
+                    // Not our failure to retry: the reconnect monitor owns a dropped session and
+                    // re-runs startProxies() itself when it comes back.
+                    return;
+                }
+                boolean healthy;
+                try {
+                    healthy = selfTest();
+                } catch (RuntimeException ex) {
+                    Logger.getLogger(App.class.getName()).log(Level.WARNING,
+                            "Self-test retry failed", ex);
+                    healthy = false;
+                }
+                if (healthy) {
+                    setReady(true);
+                    writeReadyFile();
+                    Logger.getLogger(App.class.getName()).log(Level.INFO,
+                            "The Tunnel self-test passed on retry {0}; the tunnel is ready.",
+                            attempts);
+                    cancelSelfTestRetry();
+                } else if (attempts >= SELF_TEST_RETRY_ATTEMPTS) {
+                    Logger.getLogger(App.class.getName()).log(Level.SEVERE,
+                            "The Tunnel self-test still fails after {0} retries; giving up. "
+                                    + "The tunnel stays not ready.", attempts);
+                    cancelSelfTestRetry();
+                }
+            }
+        }, selfTestRetryIntervalMs, selfTestRetryIntervalMs);
+    }
+
+    synchronized void cancelSelfTestRetry() {
+        if (selfTestRetryTimer != null) {
+            selfTestRetryTimer.cancel();
+            selfTestRetryTimer = null;
+        }
+    }
+
+    /** The external callback targets a temporary loopback server, outside user test targets. */
+    boolean shouldRunProxyCallbackTest() {
+        return getProxy() == null && getPacLocal() == null
+                && !"deny".equalsIgnoreCase(getLocalhostPolicy())
+                && getAllowedHosts().isUnrestricted()
+                && (getFastFail() == null || getFastFail().length == 0)
+                && (getConnectTo() == null || getConnectTo().length == 0);
     }
 
     /**
@@ -1475,6 +1728,24 @@ public class App {
                             "No --krb5-keytab given, so the ambient ticket cache will be used.");
                 }
             }
+        }
+
+        if (commandLine.hasOption("ssh-host-key")) {
+            try {
+                app.setSshHostKeyPins(ssh.HostKeyPins.parse(
+                        String.join(",", commandLine.getOptionValues("ssh-host-key"))));
+            } catch (IllegalArgumentException invalid) {
+                throw new ParseException("Invalid --ssh-host-key value: " + invalid.getMessage());
+            }
+        }
+
+        if (commandLine.hasOption("ssh-host-key-policy")) {
+            String value = commandLine.getOptionValue("ssh-host-key-policy").trim();
+            if (!value.equalsIgnoreCase("warn") && !value.equalsIgnoreCase("require")) {
+                throw new ParseException("Invalid --ssh-host-key-policy value: " + value
+                        + ". Expected warn or require.");
+            }
+            app.setSshHostKeyPolicy(value.toLowerCase(java.util.Locale.ROOT));
         }
 
         if (commandLine.hasOption("cacert-file")) {
@@ -1983,11 +2254,17 @@ public class App {
             // every request in the JVM with these credentials, whoever was asking.
             com.testingbot.tunnel.proxy.ProxySpec spec =
                     com.testingbot.tunnel.proxy.ProxySpec.parse(this.proxy);
+            // Setting it twice on one App -- reconfiguring before boot, or an embedder reusing
+            // the object -- would otherwise wrap our own authenticator in another of ours.
+            restoreDefaultAuthenticator();
             Authenticator previousDefault = Authenticator.getDefault();
-            Authenticator.setDefault(spec == null
+            Authenticator installed = spec == null
                     ? new ProxyAuth(splitted[0], splitted[1], null, -1, previousDefault)
                     : new ProxyAuth(splitted[0], splitted[1], spec.getHost(), spec.getPort(),
-                                    previousDefault));
+                                    previousDefault);
+            this.previousDefaultAuthenticator = previousDefault;
+            this.installedProxyAuthenticator = installed;
+            Authenticator.setDefault(installed);
         } else {
             this.proxyAuth = proxyAuth;
         }
@@ -2250,12 +2527,14 @@ public class App {
                         + "supplied by the API: {0}", pins.displayValues());
                 return;
             } catch (IllegalArgumentException ex) {
-                // Logged, not fatal: an unusable value from the service should not stop a tunnel
-                // that would otherwise start, and the connect path warns that it is unverified.
-                Logger.getLogger(App.class.getName()).log(Level.WARNING,
-                    "Ignoring unusable host key fingerprint from the API ({0}): {1}",
-                    new Object[]{field, ex.getMessage()});
-                return;
+                // Fatal, not warned past. The service sending this field at all means it meant
+                // this connection to be verified, so a value that cannot be parsed is either a
+                // bug or something on the path having rewritten it -- and continuing would hand
+                // the account secret to an unverified server on exactly the occasion where
+                // somebody tried to stop that being checked.
+                throw new TunnelFailedException("The API supplied a host key fingerprint ("
+                    + field + ") that cannot be used: " + ex.getMessage()
+                    + ". Refusing to connect unverified.", 1, ex);
             }
         }
     }
@@ -2273,6 +2552,26 @@ public class App {
     public void setSshHostKeyPins(ssh.HostKeyPins pins) {
         this.sshHostKeyPins = pins == null ? ssh.HostKeyPins.none() : pins;
         this.sshHostKeyPinsFromApi = false;
+    }
+
+    /**
+     * @return "warn" or "require", never null
+     */
+    public String getSshHostKeyPolicy() {
+        return sshHostKeyPolicy;
+    }
+
+    /**
+     * @param policy "warn" or "require"; blank restores the default
+     */
+    public void setSshHostKeyPolicy(String policy) {
+        this.sshHostKeyPolicy = policy == null || policy.trim().isEmpty()
+                ? HOST_KEY_POLICY_WARN : policy.trim().toLowerCase(java.util.Locale.ROOT);
+    }
+
+    /** True when the connection must not be made without a fingerprint to verify against. */
+    public boolean requiresVerifiedSshHostKey() {
+        return HOST_KEY_POLICY_REQUIRE.equals(sshHostKeyPolicy);
     }
 
     /**

--- a/src/main/java/com/testingbot/tunnel/ConfigFile.java
+++ b/src/main/java/com/testingbot/tunnel/ConfigFile.java
@@ -51,14 +51,23 @@ public final class ConfigFile {
      * @throws ParseException if the file is missing, unreadable, or contains unknown keys
      */
     public static String[] expand(String[] args, Options options) throws ParseException {
+        return expandWithSources(args, options).arguments();
+    }
+
+    /** Keeps explicit false values present when the environment is merged afterwards. */
+    public record Expansion(String[] arguments, java.util.Set<String> configuredOptions) {
+    }
+
+    public static Expansion expandWithSources(String[] args, Options options) throws ParseException {
         String path = findValue(args, "config");
         if (path == null) {
-            return args;
+            return new Expansion(args, java.util.Set.of());
         }
 
         Properties properties = read(Path.of(path));
         List<String> merged = new ArrayList<>(List.of(args));
         List<String> trailing = new ArrayList<>();
+        java.util.Set<String> configured = new java.util.HashSet<>();
 
         for (Map.Entry<String, String> entry : ordered(properties).entrySet()) {
             String key = entry.getKey();
@@ -73,6 +82,9 @@ public final class ConfigFile {
             Option option = options.getOption(key);
             if (option == null) {
                 throw new ParseException("Unknown setting '" + key + "' in config file " + path);
+            }
+            if (option.getLongOpt() != null) {
+                configured.add(option.getLongOpt());
             }
             if (isPresent(args, key, options)) {
                 // An explicit command-line flag beats the file.
@@ -100,7 +112,7 @@ public final class ConfigFile {
         }
         out.addAll(List.of(args));
         out.addAll(merged.subList(args.length, merged.size()));
-        return out.toArray(new String[0]);
+        return new Expansion(out.toArray(new String[0]), java.util.Set.copyOf(configured));
     }
 
     /**

--- a/src/main/java/com/testingbot/tunnel/Doctor.java
+++ b/src/main/java/com/testingbot/tunnel/Doctor.java
@@ -102,10 +102,18 @@ public final class Doctor {
     public void checkSshHostKeyPins() {
         ssh.HostKeyPins pins = app.getSshHostKeyPins();
         if (pins == null || pins.isEmpty()) {
+            if (app.requiresVerifiedSshHostKey()) {
+                Logger.getLogger(Doctor.class.getName()).log(Level.SEVERE,
+                    "FAIL - no host key fingerprint is available and --ssh-host-key-policy is "
+                        + "'require', so the tunnel will refuse to connect. Supply one with "
+                        + "--ssh-host-key.");
+                return;
+            }
             Logger.getLogger(Doctor.class.getName()).log(Level.WARNING,
                 "WARN - the tunnel server's SSH host key will not be verified. The account "
                     + "secret is that connection's password, so it goes to whatever answers. "
-                    + "The API did not supply a fingerprint for this tunnel.");
+                    + "No --ssh-host-key was given and the API supplied no fingerprint for this "
+                    + "tunnel. Use --ssh-host-key-policy require to refuse an unverified server.");
             return;
         }
         Logger.getLogger(Doctor.class.getName()).log(Level.INFO,

--- a/src/main/java/com/testingbot/tunnel/EnvOptions.java
+++ b/src/main/java/com/testingbot/tunnel/EnvOptions.java
@@ -51,12 +51,26 @@ public final class EnvOptions {
         return expand(args, options, System.getenv());
     }
 
+    public static String[] expand(ConfigFile.Expansion config, Options options) {
+        return expand(config, options, System.getenv());
+    }
+
+    static String[] expand(ConfigFile.Expansion config, Options options,
+                           Map<String, String> environment) {
+        return expand(config.arguments(), options, environment, config.configuredOptions());
+    }
+
     /**
      * Appends flags for any option set in {@code environment} but absent from {@code args}.
      *
      * @param args the command line, already expanded from any {@code --config} file
      */
     static String[] expand(String[] args, Options options, Map<String, String> environment) {
+        return expand(args, options, environment, Set.of());
+    }
+
+    private static String[] expand(String[] args, Options options, Map<String, String> environment,
+                                    Set<String> configuredOptions) {
         if (options == null || environment.isEmpty()) {
             return args;
         }
@@ -67,7 +81,7 @@ public final class EnvOptions {
             if (longOpt == null || NEVER.contains(longOpt) || HANDLED_ELSEWHERE.contains(longOpt)) {
                 continue;
             }
-            if (ConfigFile.isPresent(args, longOpt, options)) {
+            if (configuredOptions.contains(longOpt) || ConfigFile.isPresent(args, longOpt, options)) {
                 // Explicitly given on the command line or via --config; those win.
                 continue;
             }

--- a/src/main/java/com/testingbot/tunnel/HttpProxy.java
+++ b/src/main/java/com/testingbot/tunnel/HttpProxy.java
@@ -22,7 +22,6 @@ import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
@@ -358,11 +357,11 @@ public final class HttpProxy {
                 .setRedirectsEnabled(false)
                 .build();
 
-            try (CloseableHttpClient http = HttpClients.custom()
+            try (CloseableHttpClient http = Api.controlPlaneBuilder(app)
                 .setDefaultRequestConfig(cfg)
                 .build()) {
 
-                HttpPost post = new HttpPost("https://api.testingbot.com/v1/tunnel/test");
+                HttpPost post = new HttpPost(testUrl());
                 List<NameValuePair> form = Arrays.asList(
                     new BasicNameValuePair("client_key",    app.getClientKey()),
                     new BasicNameValuePair("client_secret", app.getClientSecret()),
@@ -389,6 +388,12 @@ public final class HttpProxy {
                 server.destroy();
             }
         }
+    }
+
+    /** Where the callback test is requested, following whatever API this App is configured for. */
+    private String testUrl() {
+        Api api = app.getApi();
+        return api == null ? new Api(app).url("/v1/tunnel/test") : api.url("/v1/tunnel/test");
     }
 
     /**

--- a/src/main/java/com/testingbot/tunnel/InsightServer.java
+++ b/src/main/java/com/testingbot/tunnel/InsightServer.java
@@ -59,7 +59,7 @@ public class InsightServer {
         routes.addMapping(org.eclipse.jetty.http.pathmap.PathSpec.from("/healthz"),
                 new LivenessHandler());
         routes.addMapping(org.eclipse.jetty.http.pathmap.PathSpec.from("/readyz"),
-                new ReadinessHandler());
+                new ReadinessHandler(app));
         server.setHandler(routes);
 
         try {
@@ -124,9 +124,17 @@ public class InsightServer {
      * rotation without killing it.
      */
     static class ReadinessHandler extends Handler.Abstract {
+        private final App app;
+
+        ReadinessHandler(App app) {
+            this.app = app;
+        }
+
         @Override
         public boolean handle(Request request, Response response, Callback callback) {
-            boolean ready = TunnelMetrics.isTunnelUp();
+            // This App's state, not the process gauge: a host application running two tunnels
+            // had each metrics port answering for whichever one wrote last.
+            boolean ready = app.isReady();
             response.setStatus(ready ? HttpStatus.OK_200 : HttpStatus.SERVICE_UNAVAILABLE_503);
             response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/json");
             Content.Sink.write(response, true,

--- a/src/main/java/com/testingbot/tunnel/pac/PacPolicy.java
+++ b/src/main/java/com/testingbot/tunnel/pac/PacPolicy.java
@@ -18,9 +18,7 @@ import java.util.logging.Logger;
  * file has to come from somewhere (a path or a URL, as browsers accept both), and the answer has
  * to be cheap enough to ask on every request.
  *
- * <p>Results are cached per host. PAC files are pure functions of the URL and host in all but
- * the time-dependent predicates, and re-running an interpreter for every request to the same
- * origin would be waste. The cache is bounded, because a tunnel can be pointed at a very large
+ * <p>Results are cached by URL and host, with expiry for time-dependent predicates. The cache is bounded, because a tunnel can be pointed at a very large
  * number of hosts and an unbounded map here would be a slow leak.
  */
 public final class PacPolicy {
@@ -302,10 +300,8 @@ public final class PacPolicy {
         // Keyed by the whole evaluation input, not by host. FindProxyForURL is handed url and
         // host, and a PAC file may branch on either; caching by host alone let the first
         // decision for a host stand in for every other, so a client could choose which one
-        // applied by arranging which request arrived first. Callers pass a synthetic
-        // "scheme://host:port/", so this stays one entry per scheme and port rather than
-        // growing per path -- a CONNECT to host:443 and a ws:// upgrade to host:80 are
-        // different questions and no longer share an answer.
+        // applied by arranging which request arrived first. HTTP and WebSocket callers supply
+        // the full URL; CONNECT only exposes an authority and uses a synthetic HTTPS URL.
         String key = cacheKey(url, host);
         CachedResult cached = cache.get(key);
         if (cached != null && now - cached.decidedAtMs() < CACHE_TTL_MS) {

--- a/src/main/java/com/testingbot/tunnel/proxy/CustomConnectHandler.java
+++ b/src/main/java/com/testingbot/tunnel/proxy/CustomConnectHandler.java
@@ -102,8 +102,7 @@ public class CustomConnectHandler extends ConnectHandler {
      * necessarily the one the credentials were issued for.
      */
     private boolean isConfiguredProxy(ProxySpec upstream) {
-        return proxySpec != null && upstream != null
-                && proxySpec.getHost().equalsIgnoreCase(upstream.getHost());
+        return proxySpec != null && proxySpec.sameEndpoint(upstream);
     }
 
     /**
@@ -725,7 +724,8 @@ public class CustomConnectHandler extends ConnectHandler {
 
         // Sent pre-emptively rather than after a 407: a proxy that does not want it ignores it,
         // and waiting for the challenge would mean replaying the whole exchange.
-        String authorization = proxyAuthenticator.authorizationValue(upstream.getHost());
+        String authorization = isConfiguredProxy(upstream)
+                ? proxyAuthenticator.authorizationValue(upstream.getHost()) : null;
         if (authorization != null) {
             connect.append("Proxy-Authorization: ").append(authorization).append("\r\n");
         }

--- a/src/main/java/com/testingbot/tunnel/proxy/ForwarderHandler.java
+++ b/src/main/java/com/testingbot/tunnel/proxy/ForwarderHandler.java
@@ -102,7 +102,8 @@ public class ForwarderHandler extends ProxyHandler.Reverse {
         }
 
         JUL.log(Level.INFO, "[{0}] {1}",
-                new Object[]{clientToProxyRequest.getMethod(), clientToProxyRequest.getHttpURI()});
+                new Object[]{clientToProxyRequest.getMethod(),
+                        SensitiveHeaders.redactUrl(clientToProxyRequest.getHttpURI().toString())});
 
         if (mode.includesHeaders() || app.isDebugMode()) {
             StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/testingbot/tunnel/proxy/HttpLogHandler.java
+++ b/src/main/java/com/testingbot/tunnel/proxy/HttpLogHandler.java
@@ -155,7 +155,7 @@ public class HttpLogHandler extends Handler.Wrapper {
         if (request.getHttpURI().getPath() == null && authority != null) {
             return authority;
         }
-        return request.getHttpURI().toString();
+        return SensitiveHeaders.redactUrl(request.getHttpURI().toString());
     }
 
     private static String newRequestId() {

--- a/src/main/java/com/testingbot/tunnel/proxy/ProxyAuthenticator.java
+++ b/src/main/java/com/testingbot/tunnel/proxy/ProxyAuthenticator.java
@@ -47,9 +47,8 @@ public final class ProxyAuthenticator {
      * whoever was being connected to -- and with {@code --pac-local} the PAC file chooses that
      * host per destination.
      *
-     * <p>Matched on host, not host:port, because that is all the dial sites know at the point
-     * they ask. A different port on the same proxy host is the same proxy in every deployment
-     * this has, and narrowing further would refuse credentials to a proxy that should have them.
+     * <p>The routing handlers also require {@link ProxySpec#sameEndpoint} before requesting a
+     * token, so a PAC result on a different port or protocol cannot receive these credentials.
      */
     private final String authorizedHost;
 

--- a/src/main/java/com/testingbot/tunnel/proxy/ProxyNegotiateScheme.java
+++ b/src/main/java/com/testingbot/tunnel/proxy/ProxyNegotiateScheme.java
@@ -1,0 +1,74 @@
+package com.testingbot.tunnel.proxy;
+
+import java.security.Principal;
+import org.apache.hc.client5.http.auth.AuthChallenge;
+import org.apache.hc.client5.http.auth.AuthScheme;
+import org.apache.hc.client5.http.auth.AuthenticationException;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+/** Adapts the tunnel's Kerberos credentials to HttpClient's proxy challenge handling. */
+public final class ProxyNegotiateScheme implements AuthScheme {
+    private final ProxySpec proxy;
+    private final ProxyAuthenticator authenticator;
+    private boolean complete;
+
+    public ProxyNegotiateScheme(ProxySpec proxy, ProxyAuthenticator authenticator) {
+        this.proxy = proxy;
+        this.authenticator = authenticator;
+    }
+
+    @Override
+    public String getName() {
+        return "Negotiate";
+    }
+
+    @Override
+    public boolean isConnectionBased() {
+        return false;
+    }
+
+    @Override
+    public void processChallenge(AuthChallenge challenge, HttpContext context) {
+        // The shared authenticator emits a single Kerberos token. A second rejection must
+        // terminate authentication rather than loop or fall back to Basic credentials.
+        complete = true;
+    }
+
+    @Override
+    public boolean isChallengeComplete() {
+        return complete;
+    }
+
+    @Override
+    public String getRealm() {
+        return null;
+    }
+
+    @Override
+    public Principal getPrincipal() {
+        return null;
+    }
+
+    @Override
+    public boolean isResponseReady(HttpHost host, CredentialsProvider credentials, HttpContext context) {
+        return host != null && "http".equalsIgnoreCase(host.getSchemeName())
+                && proxy.getHost().equalsIgnoreCase(host.getHostName())
+                && proxy.getPort() == host.getPort();
+    }
+
+    @Override
+    public String generateAuthResponse(HttpHost host, HttpRequest request, HttpContext context)
+            throws AuthenticationException {
+        if (!isResponseReady(host, null, context)) {
+            throw new AuthenticationException("Negotiate credentials are scoped to the configured proxy");
+        }
+        String value = authenticator.authorizationValue(proxy.getHost());
+        if (value == null) {
+            throw new AuthenticationException("Could not obtain a Negotiate token for the control proxy");
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/testingbot/tunnel/proxy/ProxySpec.java
+++ b/src/main/java/com/testingbot/tunnel/proxy/ProxySpec.java
@@ -40,6 +40,12 @@ public final class ProxySpec {
         return type == Type.SOCKS5;
     }
 
+    /** Credentials belong to one protocol, host and port, including for PAC-selected peers. */
+    public boolean sameEndpoint(ProxySpec other) {
+        return other != null && type == other.type && port == other.port
+                && host.equalsIgnoreCase(other.host);
+    }
+
     /**
      * @return the parsed spec, or null when {@code spec} is blank or malformed
      */

--- a/src/main/java/com/testingbot/tunnel/proxy/SensitiveHeaders.java
+++ b/src/main/java/com/testingbot/tunnel/proxy/SensitiveHeaders.java
@@ -3,6 +3,13 @@ package com.testingbot.tunnel.proxy;
 import java.util.Locale;
 import java.util.Set;
 
+/**
+ * What must not reach whatever collects these logs.
+ *
+ * <p>Header names and request targets both, because a credential travels in either: the default
+ * {@code --log-http errors} mode prints the full request URI for every failed request, and a
+ * query string is where a signed URL or an access key routinely sits.
+ */
 final class SensitiveHeaders {
     static final String REDACTED = "<redacted>";
 
@@ -12,7 +19,9 @@ final class SensitiveHeaders {
             "cookie",
             "set-cookie",
             "x-api-key",
-            "x-auth-token"
+            "x-auth-token",
+            // The Selenium relay's own: the account key and secret, joined by an underscore.
+            "tb-credentials"
     );
 
     private SensitiveHeaders() {
@@ -24,5 +33,69 @@ final class SensitiveHeaders {
 
     static String redactValue(String name, String value) {
         return isSensitive(name) ? REDACTED : value;
+    }
+
+    /**
+     * A request target with its userinfo and any credential-shaped query values removed.
+     *
+     * <p>Parsed by hand rather than through {@link java.net.URI}: this proxy exists partly to
+     * forward the lenient query strings browsers send and {@code URI} rejects, so anything that
+     * failed to parse would be logged unredacted -- and a target that reaches the log is one
+     * this code has already decided to be lenient about.
+     *
+     * <p>Query keys are judged by {@link BodyRedactor#isSensitiveKey}, so a name recognised in a
+     * request body is recognised here too.
+     */
+    static String redactUrl(String target) {
+        if (target == null || target.isEmpty()) {
+            return target;
+        }
+        String result = redactUserInfo(target);
+        int query = result.indexOf('?');
+        if (query < 0) {
+            return result;
+        }
+        int end = result.indexOf('#', query);
+        String prefix = result.substring(0, query + 1);
+        String suffix = end < 0 ? "" : result.substring(end);
+        String queryString = end < 0 ? result.substring(query + 1) : result.substring(query + 1, end);
+
+        StringBuilder redacted = new StringBuilder(prefix);
+        String[] parameters = queryString.split("&", -1);
+        for (int i = 0; i < parameters.length; i++) {
+            if (i > 0) {
+                redacted.append('&');
+            }
+            String parameter = parameters[i];
+            int equals = parameter.indexOf('=');
+            if (equals > 0 && BodyRedactor.isSensitiveKey(parameter.substring(0, equals))) {
+                redacted.append(parameter, 0, equals + 1).append(REDACTED);
+            } else {
+                redacted.append(parameter);
+            }
+        }
+        return redacted.append(suffix).toString();
+    }
+
+    /** {@code http://user:password@host/} -- the password is a credential like any other. */
+    private static String redactUserInfo(String target) {
+        int schemeEnd = target.indexOf("://");
+        if (schemeEnd < 0) {
+            return target;
+        }
+        int authorityStart = schemeEnd + 3;
+        int authorityEnd = target.length();
+        for (int i = authorityStart; i < target.length(); i++) {
+            char c = target.charAt(i);
+            if (c == '/' || c == '?' || c == '#') {
+                authorityEnd = i;
+                break;
+            }
+        }
+        int at = target.lastIndexOf('@', authorityEnd - 1);
+        if (at < authorityStart) {
+            return target;
+        }
+        return target.substring(0, authorityStart) + REDACTED + target.substring(at);
     }
 }

--- a/src/main/java/com/testingbot/tunnel/proxy/TunnelProxyHandler.java
+++ b/src/main/java/com/testingbot/tunnel/proxy/TunnelProxyHandler.java
@@ -133,6 +133,7 @@ public class TunnelProxyHandler extends ProxyHandler.Forward {
         boolean httpProxy = spec != null && !spec.isSocks5();
         this.upstreamHttpProxyHost = httpProxy ? spec.getHost() : null;
         this.upstreamHttpProxySpec = httpProxy ? spec : null;
+        this.proxyAuthHeaderValue = null;
         if (httpProxy && userPassword != null && !userPassword.isEmpty()) {
             this.proxyAuthHeaderValue = "Basic " + java.util.Base64.getEncoder()
                     .encodeToString(userPassword.getBytes(java.nio.charset.StandardCharsets.UTF_8));
@@ -178,28 +179,25 @@ public class TunnelProxyHandler extends ProxyHandler.Forward {
      * the origin. With no upstream proxy there is no tunnel and nothing to withhold.
      */
     boolean isTunnelledToOrigin(org.eclipse.jetty.client.Request proxyToServerRequest) {
-        return upstreamHttpProxyHost != null
+        ProxySpec chosen = selectedProxy(proxyToServerRequest);
+        return chosen != null && !chosen.isSocks5()
                 && org.eclipse.jetty.http.HttpScheme.HTTPS.is(
                         proxyToServerRequest.getURI() == null
                                 ? proxyToServerRequest.getScheme()
                                 : proxyToServerRequest.getURI().getScheme());
     }
 
-    /** True when the upstream chosen for this request is the proxy {@code --proxy} names. */
-    private boolean goesToTheConfiguredProxy(org.eclipse.jetty.client.Request proxyToServerRequest) {
-        if (upstreamHttpProxySpec == null) {
-            return false;
+    /** Uses the route already chosen for this exchange; PAC must not be re-evaluated here. */
+    private boolean goesToTheConfiguredProxy(org.eclipse.jetty.client.Request request) {
+        ProxySpec chosen = selectedProxy(request);
+        return upstreamHttpProxySpec != null && upstreamHttpProxySpec.sameEndpoint(chosen);
+    }
+
+    private ProxySpec selectedProxy(org.eclipse.jetty.client.Request request) {
+        if (pacPolicy == null) {
+            return ProxySpec.parse(upstreamProxy);
         }
-        String host = proxyToServerRequest.getHost();
-        int port = proxyToServerRequest.getPort();
-        if (port <= 0) {
-            port = HttpScheme.HTTPS.is(proxyToServerRequest.getScheme()) ? 443 : 80;
-        }
-        ProxySpec chosen = upstreamFor(host, port, proxyToServerRequest.getScheme());
-        return chosen != null
-                && !chosen.isSocks5()
-                && chosen.getPort() == upstreamHttpProxySpec.getPort()
-                && chosen.getHost().equalsIgnoreCase(upstreamHttpProxySpec.getHost());
+        return request.getTag() instanceof String key ? ProxySpec.parse(key) : null;
     }
 
     /** Splits "user:password"; the password may itself contain colons. */
@@ -285,6 +283,10 @@ public class TunnelProxyHandler extends ProxyHandler.Forward {
      * retry loop around jetty-client's exchange.
      */
     ProxySpec upstreamFor(String host, int port, String scheme) {
+        return upstreamFor(absoluteForm(scheme, host, port, "/"), host);
+    }
+
+    private ProxySpec upstreamFor(String url, String host) {
         if (pacPolicy == null) {
             return ProxySpec.parse(upstreamProxy);
         }
@@ -292,7 +294,7 @@ public class TunnelProxyHandler extends ProxyHandler.Forward {
             return null;
         }
         com.testingbot.tunnel.pac.PacResult result =
-                pacPolicy.resolveOrNull(scheme + "://" + host + ":" + port + "/", host);
+                pacPolicy.resolveOrNull(url, host);
         if (result == null) {
             // Could not evaluate: fall through to --proxy rather than direct, so a broken file
             // does not silently bypass the network's only sanctioned egress.
@@ -335,25 +337,14 @@ public class TunnelProxyHandler extends ProxyHandler.Forward {
     }
 
     /**
-     * Makes sure jetty-client knows about the proxy PAC chose for this destination.
-     *
-     * <p>jetty-client picks an upstream by walking {@link ProxyConfiguration}'s list and taking
-     * the first {@code Proxy} whose {@code matches(Origin)} answers true -- a fixed address per
-     * entry, which a PAC file is not. So each distinct proxy the file has named gets one entry
-     * whose {@code matches} re-asks the PAC and claims only the origins routed to itself; a host
-     * the file sends DIRECT is claimed by none of them and dialled directly.
-     *
-     * <p>Registration happens here, on the request thread before the exchange is created, rather
-     * than from inside {@code matches()}: {@code match()} iterates the list, and growing it
-     * during that walk is how this would become an intermittent failure under load.
-     *
-     * @return the proxy key for this destination, used as the request tag
+     * Registers the chosen proxy before creating the exchange. The request tag carries this
+     * route into Origin selection, so paths on one host can use different connection pools
+     * without re-evaluating a time-dependent PAC decision during authentication or dialing.
      */
-    private String registerPacProxy(String host, int port, String scheme) {
+    private String registerPacProxy(ProxySpec chosen) {
         if (pacPolicy == null) {
             return null;
         }
-        ProxySpec chosen = upstreamFor(host, port, scheme);
         String key = proxyKey(chosen);
         if (key == null) {
             return null;
@@ -389,8 +380,7 @@ public class TunnelProxyHandler extends ProxyHandler.Forward {
 
         @Override
         public boolean matches(Origin origin) {
-            return key.equals(proxyKey(upstreamFor(origin.getAddress().getHost(),
-                    origin.getAddress().getPort(), origin.getScheme())));
+            return key.equals(origin.getTag());
         }
     }
 
@@ -405,8 +395,7 @@ public class TunnelProxyHandler extends ProxyHandler.Forward {
 
         @Override
         public boolean matches(Origin origin) {
-            return key.equals(proxyKey(upstreamFor(origin.getAddress().getHost(),
-                    origin.getAddress().getPort(), origin.getScheme())));
+            return key.equals(origin.getTag());
         }
     }
 
@@ -829,7 +818,8 @@ public class TunnelProxyHandler extends ProxyHandler.Forward {
         }
         // Before the request is created, so the proxy PAC chose is already in the client's
         // configuration when jetty-client resolves the destination and asks which one matches.
-        String pacTag = registerPacProxy(newHttpURI.getHost(), port, newHttpURI.getScheme());
+        ProxySpec chosen = upstreamFor(newHttpURI.asString(), newHttpURI.getHost());
+        String pacTag = registerPacProxy(chosen);
 
         org.eclipse.jetty.client.Request proxyRequest =
                 getHttpClient().newRequest(newHttpURI.getHost(), port)
@@ -857,7 +847,8 @@ public class TunnelProxyHandler extends ProxyHandler.Forward {
         // to pass through ("?a={json}", "?next=a|b", "?tpl={{name}}"), because java.net.URI
         // rejects them. Those requests would reach the upstream proxy in origin-form, which
         // Squid answers with 400. Absolutize them here, the same way jetty-client would.
-        if (usesHttpUpstreamProxy() && proxyRequest.getURI() == null) {
+        if (chosen != null && !chosen.isSocks5()
+                && !HttpScheme.HTTPS.is(newHttpURI.getScheme()) && proxyRequest.getURI() == null) {
             proxyRequest.path(absoluteForm(newHttpURI.getScheme(), newHttpURI.getHost(), port, pathQuery));
         }
         return proxyRequest;
@@ -886,12 +877,6 @@ public class TunnelProxyHandler extends ProxyHandler.Forward {
         }
         // Same port as ours: only a loop if it also names this machine.
         return LocalhostPolicy.DENY.blocks(targetHost);
-    }
-
-    /** True when traffic leaves through an HTTP forward proxy. SOCKS5 is transparent at TCP level. */
-    private boolean usesHttpUpstreamProxy() {
-        ProxySpec spec = ProxySpec.parse(upstreamProxy);
-        return spec != null && !spec.isSocks5();
     }
 
     static String absoluteForm(String scheme, String host, int port, String pathQuery) {

--- a/src/main/java/com/testingbot/tunnel/proxy/WebsocketHandler.java
+++ b/src/main/java/com/testingbot/tunnel/proxy/WebsocketHandler.java
@@ -104,8 +104,7 @@ public class WebsocketHandler extends ConnectHandler {
 
     /** True when {@code upstream} is the proxy {@code --proxy} named; see CustomConnectHandler. */
     private boolean isConfiguredProxy(ProxySpec upstream) {
-        return proxySpec != null && upstream != null
-                && proxySpec.getHost().equalsIgnoreCase(upstream.getHost());
+        return proxySpec != null && proxySpec.sameEndpoint(upstream);
     }
 
     /**
@@ -115,12 +114,16 @@ public class WebsocketHandler extends ConnectHandler {
      * without a PAC file this is just the static {@code --proxy}.
      */
     ProxySpec upstreamFor(String host, int port) {
+        return upstreamFor(TunnelProxyHandler.absoluteForm("http", host, port, "/"), host);
+    }
+
+    private ProxySpec upstreamFor(String url, String host) {
         if (pacPolicy == null) {
             return proxySpec;
         }
         // ws:// is carried over HTTP, so that is the scheme a PAC file is asked about.
         com.testingbot.tunnel.pac.PacResult result =
-                pacPolicy.resolveOrNull("http://" + host + ":" + port + "/", host);
+                pacPolicy.resolveOrNull(url, host);
         if (result == null) {
             // Could not evaluate: fall through to --proxy rather than direct, so a broken file
             // does not silently bypass the network's only sanctioned egress.
@@ -340,7 +343,7 @@ public class WebsocketHandler extends ConnectHandler {
     @Override
     protected void connectToServer(Request request, String host, int port, Promise<SocketChannel> promise) {
         request.setAttribute(WS_TARGET_ATTRIBUTE, Boolean.TRUE);
-        ProxySpec upstream = upstreamFor(host, port);
+        ProxySpec upstream = upstreamFor(request.getHttpURI().asString(), host);
         if (upstream != null) {
             request.setAttribute(WS_PROXY_TARGET_ATTRIBUTE, new ProxyTarget(upstream, host, port));
         }
@@ -505,8 +508,8 @@ public class WebsocketHandler extends ConnectHandler {
                     .append(proxyTarget.port()).append(" HTTP/1.1\r\n");
             connect.append("Host: ").append(proxyTarget.host()).append(':')
                     .append(proxyTarget.port()).append("\r\n");
-            String authorization =
-                    proxyAuthenticator.authorizationValue(proxyTarget.upstream().getHost());
+            String authorization = isConfiguredProxy(proxyTarget.upstream())
+                    ? proxyAuthenticator.authorizationValue(proxyTarget.upstream().getHost()) : null;
             if (authorization != null) {
                 connect.append("Proxy-Authorization: ").append(authorization).append("\r\n");
             }
@@ -523,7 +526,7 @@ public class WebsocketHandler extends ConnectHandler {
             // peer. After a CONNECT or a SOCKS handshake the peer is the target itself.
             boolean throughHttpProxy = proxyTarget != null
                     && !proxyTarget.upstream().isSocks5() && !upgradeViaConnect;
-            String authorization = throughHttpProxy
+            String authorization = throughHttpProxy && isConfiguredProxy(proxyTarget.upstream())
                     ? proxyAuthenticator.authorizationValue(proxyTarget.upstream().getHost())
                     : null;
             ByteBuffer request = ByteBuffer.wrap(

--- a/src/main/java/ssh/CustomConnectionMonitor.java
+++ b/src/main/java/ssh/CustomConnectionMonitor.java
@@ -34,6 +34,8 @@ public class CustomConnectionMonitor {
 
     private final AtomicBoolean retrying = new AtomicBoolean(false);
     private int retryAttempts = 0;
+    private final Object lifecycleLock = new Object();
+    private volatile boolean cancelled;
 
     public CustomConnectionMonitor(SSHTunnel tunnel, App app) {
         this(tunnel, ReconnectHost.of(app), Scheduler.timerBased(), CURRENT_RETRY_DELAY);
@@ -48,23 +50,25 @@ public class CustomConnectionMonitor {
     }
 
     public void connectionLost(Throwable reason) {
-        if (tunnel.isShuttingDown()) {
-            // A drop during a deliberate shutdown is expected, not something to recover from.
-            return;
-        }
+        synchronized (lifecycleLock) {
+            if (isStopped()) {
+                // A drop during a deliberate shutdown is expected, not something to recover from.
+                return;
+            }
 
-        TunnelMetrics.setTunnelUp(false);
-        TunnelMetrics.ERRORS_TOTAL.labels("ssh_connection_lost").inc();
+            host.setReady(false);
+            TunnelMetrics.ERRORS_TOTAL.labels("ssh_connection_lost").inc();
 
-        host.stopLocalProxy();
+            host.stopLocalProxy();
 
-        LOG.log(Level.SEVERE, String.format("[%s] SSH Connection lost! %s",
-                tunnel.getConnectionId(), reason == null ? "" : reason.getMessage()));
+            LOG.log(Level.SEVERE, String.format("[%s] SSH Connection lost! %s",
+                    tunnel.getConnectionId(), reason == null ? "" : reason.getMessage()));
 
-        // Only the first loss starts a retry cycle; further reports while one is already in
-        // flight would otherwise stack up timers all racing to reconnect the same tunnel.
-        if (retrying.compareAndSet(false, true)) {
-            scheduleRetry();
+            // Only the first loss starts a retry cycle; further reports while one is already in
+            // flight would otherwise stack up timers all racing to reconnect the same tunnel.
+            if (retrying.compareAndSet(false, true)) {
+                scheduleRetry();
+            }
         }
     }
 
@@ -73,11 +77,18 @@ public class CustomConnectionMonitor {
     }
 
     private void scheduleRetry(Runnable task) {
-        scheduler.scheduleOnce("Reconnect-" + tunnel.getConnectionId(), task, retryDelayMs);
+        synchronized (lifecycleLock) {
+            if (!isStopped()) {
+                scheduler.scheduleOnce("Reconnect-" + tunnel.getConnectionId(), task, retryDelayMs);
+            }
+        }
     }
 
     /** One reconnect attempt. Package-private so a test can drive it without the scheduler. */
     void attemptReconnect() {
+        if (isStopped()) {
+            return;
+        }
         try {
             retryAttempts += 1;
             TunnelMetrics.TUNNEL_RECONNECTS_TOTAL.inc();
@@ -87,7 +98,14 @@ public class CustomConnectionMonitor {
                     tunnel.getConnectionId(), retryAttempts, retryDelayMs));
 
             tunnel.stop();
+            if (isStopped()) {
+                return;
+            }
             tunnel.connect();
+            if (isStopped()) {
+                tunnel.stop();
+                return;
+            }
 
             if (tunnel.isAuthenticated()) {
                 onReconnected();
@@ -119,7 +137,12 @@ public class CustomConnectionMonitor {
         // thirty pointless reconnects and a full tunnel rebuild, with nothing in the log naming
         // the port.
         try {
-            host.startLocalProxy();
+            synchronized (lifecycleLock) {
+                if (isStopped()) {
+                    return;
+                }
+                host.startLocalProxy();
+            }
         } catch (RuntimeException proxyFailed) {
             LOG.log(Level.SEVERE, String.format(
                     "[%s] SSH reconnected, but the local proxy could not be restarted: %s",
@@ -144,16 +167,33 @@ public class CustomConnectionMonitor {
 
     /** The part common to a clean reconnect and one that needed the proxy retried. */
     private void finishReconnect() {
-        retrying.set(false);
-        scheduler.cancel();
-
+        if (isStopped()) {
+            return;
+        }
         tunnel.createPortForwarding();
-        TunnelMetrics.setTunnelUp(true);
-
-        LOG.log(Level.INFO, String.format(
-                "[%s] Successfully re-established SSH Connection after %d attempts",
-                tunnel.getConnectionId(), retryAttempts));
-        retryAttempts = 0;
+        synchronized (lifecycleLock) {
+            if (isStopped()) {
+                tunnel.stop();
+                return;
+            }
+            if (!tunnel.isAuthenticated() || !tunnel.isForwardingEstablished()) {
+                host.setReady(false);
+                LOG.log(Level.WARNING, "SSH reconnected but port forwarding failed; retrying setup");
+                if (retryAttempts >= MAX_RETRIES) {
+                    giveUpAndRebuild();
+                } else {
+                    scheduleRetry();
+                }
+                return;
+            }
+            retrying.set(false);
+            scheduler.cancel();
+            host.setReady(true);
+            LOG.log(Level.INFO, String.format(
+                    "[%s] Successfully re-established SSH Connection after %d attempts",
+                    tunnel.getConnectionId(), retryAttempts));
+            retryAttempts = 0;
+        }
     }
 
     /**
@@ -165,9 +205,17 @@ public class CustomConnectionMonitor {
      * to the rebuild, which stops the whole App and so releases it.
      */
     private void retryLocalProxy() {
+        if (isStopped()) {
+            return;
+        }
         retryAttempts += 1;
         try {
-            host.startLocalProxy();
+            synchronized (lifecycleLock) {
+                if (isStopped()) {
+                    return;
+                }
+                host.startLocalProxy();
+            }
         } catch (RuntimeException proxyFailed) {
             LOG.log(Level.WARNING, String.format(
                     "[%s] Local proxy restart attempt %d failed: %s",
@@ -183,6 +231,9 @@ public class CustomConnectionMonitor {
     }
 
     private void giveUpAndRebuild() {
+        if (isStopped()) {
+            return;
+        }
         LOG.log(Level.WARNING, String.format(
                 "[%s] Giving up retrying after %d attempts. Creating a new Tunnel Connection.",
                 tunnel.getConnectionId(), retryAttempts));
@@ -197,6 +248,20 @@ public class CustomConnectionMonitor {
             LOG.log(Level.SEVERE, String.format("[%s] Failed to create new tunnel: %s",
                     tunnel.getConnectionId(), ex.getMessage()), ex);
         }
+    }
+
+    /** Stops the retry scheduler, including callbacks racing its cancellation. */
+    public void cancel() {
+        synchronized (lifecycleLock) {
+            cancelled = true;
+            scheduler.cancel();
+            retrying.set(false);
+            host.setReady(false);
+        }
+    }
+
+    private boolean isStopped() {
+        return cancelled || tunnel.isShuttingDown();
     }
 
     /** Attempts made in the current retry cycle; for tests and diagnostics. */

--- a/src/main/java/ssh/ReconnectHost.java
+++ b/src/main/java/ssh/ReconnectHost.java
@@ -1,6 +1,7 @@
 package ssh;
 
 import com.testingbot.tunnel.App;
+import com.testingbot.tunnel.TunnelMetrics;
 
 /**
  * The part of {@link App} that {@link CustomConnectionMonitor} needs: the local proxy has to be
@@ -17,6 +18,17 @@ public interface ReconnectHost {
 
     /** Tears the tunnel down and builds a new one, typically against a different server. */
     void rebuildTunnel() throws Exception;
+
+    /**
+     * Records whether the tunnel is forwarding.
+     *
+     * <p>Through the host rather than straight to {@code TunnelMetrics}, because readiness
+     * belongs to one App: a host application running two tunnels had a reconnect on either of
+     * them answering {@code /readyz} for both.
+     */
+    default void setReady(boolean ready) {
+        TunnelMetrics.setTunnelUp(ready);
+    }
 
     /** The production adapter. */
     static ReconnectHost of(App app) {
@@ -39,6 +51,11 @@ public interface ReconnectHost {
             public void rebuildTunnel() throws Exception {
                 app.stop();
                 app.boot();
+            }
+
+            @Override
+            public void setReady(boolean ready) {
+                app.setReady(ready);
             }
         };
     }

--- a/src/main/java/ssh/ReconnectableTunnel.java
+++ b/src/main/java/ssh/ReconnectableTunnel.java
@@ -23,4 +23,9 @@ public interface ReconnectableTunnel {
     boolean isAuthenticated();
 
     void createPortForwarding();
+
+    /** True only after both forwarding directions were established. */
+    default boolean isForwardingEstablished() {
+        return false;
+    }
 }

--- a/src/main/java/ssh/SSHTunnel.java
+++ b/src/main/java/ssh/SSHTunnel.java
@@ -24,7 +24,8 @@ import java.util.logging.Logger;
 public class SSHTunnel implements ReconnectableTunnel {
     private final App app;
     private final JSch jsch;
-    private Session session;
+    private volatile Session session;
+    private final Object lifecycleLock = new Object();
     private final String server;
     private final String connectionId;
     private Timer keepAliveTimer;
@@ -32,7 +33,10 @@ public class SSHTunnel implements ReconnectableTunnel {
     private Timer portForwardingMonitorTimer;
     private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
     private final CustomConnectionMonitor connectionMonitor;
-    private boolean portForwardingEstablished = false;
+    private volatile boolean portForwardingEstablished = false;
+
+    /** Long enough for a slow network and a proxy hop, short enough to fail rather than hang. */
+    static final int DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
 
     /** TestingBot's tunnel servers listen for SSH on 443, so egress firewalls let it out. */
     static final int DEFAULT_SSH_PORT = 443;
@@ -40,27 +44,40 @@ public class SSHTunnel implements ReconnectableTunnel {
     /** Where the Selenium forward is delivered, resolved by the tunnel server, not by us. */
     static final String DEFAULT_HUB_HOST = "hub.testingbot.com";
 
+    /** The port the tunnel server accepts browser traffic on and forwards back to us. */
+    static final int DEFAULT_REMOTE_PROXY_PORT = 2010;
+
     private final int sshPort;
     private final String hubHost;
+    private final int remoteProxyPort;
 
     public SSHTunnel(App app, String server) throws Exception {
-        this(app, server, DEFAULT_SSH_PORT, DEFAULT_HUB_HOST);
+        this(app, server, DEFAULT_SSH_PORT, DEFAULT_HUB_HOST, DEFAULT_REMOTE_PROXY_PORT);
+    }
+
+    SSHTunnel(App app, String server, int sshPort, String hubHost) throws Exception {
+        this(app, server, sshPort, hubHost, DEFAULT_REMOTE_PROXY_PORT);
     }
 
     /**
-     * @param sshPort the tunnel server's SSH port
-     * @param hubHost where the local forward is delivered
+     * @param sshPort         the tunnel server's SSH port
+     * @param hubHost         where the local forward is delivered
+     * @param remoteProxyPort the port the tunnel server listens on for browser traffic
      *
-     * <p>Both are fixed in production. They are parameters so the session handling can be tested
-     * against an in-process SSH server on an ephemeral port, forwarding to a local stand-in for
-     * the hub -- otherwise none of this code is reachable without the live service.
+     * <p>All three are fixed in production. They are parameters so the session handling can be
+     * tested against an in-process SSH server on an ephemeral port, forwarding to a local stand-in
+     * for the hub -- otherwise none of this code is reachable without the live service. The
+     * reverse forward's port is one of them because two tunnel servers are two machines there,
+     * while in one JVM they are two listeners that cannot both bind 2010.
      */
-    SSHTunnel(App app, String server, int sshPort, String hubHost) throws Exception {
+    SSHTunnel(App app, String server, int sshPort, String hubHost, int remoteProxyPort)
+            throws Exception {
         /* Create a connection instance */
         this.app = app;
         this.server = server;
         this.sshPort = sshPort;
         this.hubHost = hubHost;
+        this.remoteProxyPort = remoteProxyPort;
         this.connectionId = UUID.randomUUID().toString().substring(0, 8);
 
         this.jsch = new JSch();
@@ -119,14 +136,23 @@ public class SSHTunnel implements ReconnectableTunnel {
      * on this session is the customer's account secret, and an unverified server is one that
      * could be anybody.
      */
-    private void applyHostKeyVerification(Session session) {
+    private void applyHostKeyVerification(Session session) throws JSchException {
         HostKeyPins pins = app.getSshHostKeyPins();
         if (pins == null || pins.isEmpty()) {
+            if (app.requiresVerifiedSshHostKey()) {
+                // Asked for by --ssh-host-key-policy require: refuse before setPassword's value
+                // can reach a server nothing has vouched for.
+                throw new JSchException(String.format(
+                    "No host key fingerprint for %s:%d, and --ssh-host-key-policy is 'require'. "
+                        + "Supply one with --ssh-host-key, or use 'warn' to connect unverified.",
+                    server, sshPort));
+            }
             session.setConfig("StrictHostKeyChecking", "no");
             Logger.getLogger(SSHTunnel.class.getName()).log(Level.WARNING,
-                String.format("[%s] The tunnel server's host key is not verified: the API "
-                    + "supplied no fingerprint. The account secret is this connection's "
-                    + "password, so anything answering %s:%d receives it.",
+                String.format("[%s] The tunnel server's host key is not verified: no fingerprint "
+                    + "was configured with --ssh-host-key and the API supplied none. The account "
+                    + "secret is this connection's password, so anything answering %s:%d "
+                    + "receives it. Use --ssh-host-key-policy require to refuse this.",
                     connectionId, server, sshPort));
             return;
         }
@@ -137,7 +163,16 @@ public class SSHTunnel implements ReconnectableTunnel {
                 connectionId, pins.size()));
     }
 
+    /** Milliseconds allowed for the dial and handshake; {@code --http-dial-timeout} when set. */
+    private int connectTimeoutMs() {
+        Integer seconds = app.getHttpDialTimeoutSeconds();
+        return seconds == null ? DEFAULT_CONNECT_TIMEOUT_MS : seconds * 1000;
+    }
+
     public final void connect() throws Exception {
+        if (shuttingDown.get()) {
+            throw new IllegalStateException("Tunnel has been stopped");
+        }
         Histogram.Timer histogramTimer = TunnelMetrics.TUNNEL_CONNECT_DURATION_SECONDS.startTimer();
         try {
             /* Now connect */
@@ -146,7 +181,11 @@ public class SSHTunnel implements ReconnectableTunnel {
             session.setPassword(app.getClientSecret());
             applyHostKeyVerification(session);
             applyUpstreamProxy(session);
-            session.connect();
+            // Bounded, because connect() covers the TCP dial, the proxy's CONNECT and the SSH
+            // banner exchange: a peer that accepts the socket and then says nothing -- a
+            // silently dropping firewall, a proxy holding the connection -- otherwise left this
+            // blocked with no timeout at all, on the startup path and on every reconnect.
+            session.connect(connectTimeoutMs());
             long connectTime = System.currentTimeMillis() - startTime;
 
             TunnelMetrics.TUNNEL_CONNECTS_TOTAL.inc();
@@ -172,39 +211,51 @@ public class SSHTunnel implements ReconnectableTunnel {
             throw new Exception("Authentication failed");
         }
 
-        // Start keep-alive timer with configurable interval
-        keepAliveTimer = new Timer("KeepAlive-" + connectionId);
-        keepAliveTimer.schedule(new KeepAliveTask(), 30000, 30000);
-
-        // Start connection monitoring timer
-        connectionMonitorTimer = new Timer("ConnectionMonitor-" + connectionId);
-        connectionMonitorTimer.schedule(new ConnectionMonitorTask(), 10000, 10000);
-
-        // Start port forwarding monitoring timer
-        portForwardingMonitorTimer = new Timer("PortForwardingMonitor-" + connectionId);
-        portForwardingMonitorTimer.schedule(new PortForwardingMonitorTask(), 15000, 15000);
+        synchronized (lifecycleLock) {
+            if (shuttingDown.get()) {
+                session.disconnect();
+                throw new IllegalStateException("Tunnel stopped while connecting");
+            }
+            keepAliveTimer = new Timer("KeepAlive-" + connectionId);
+            keepAliveTimer.schedule(new KeepAliveTask(), 30000, 30000);
+            connectionMonitorTimer = new Timer("ConnectionMonitor-" + connectionId);
+            connectionMonitorTimer.schedule(new ConnectionMonitorTask(), 10000, 10000);
+            portForwardingMonitorTimer = new Timer("PortForwardingMonitor-" + connectionId);
+            portForwardingMonitorTimer.schedule(new PortForwardingMonitorTask(), 15000, 15000);
+        }
     }
 
     public void stop(boolean quitting) {
-        this.shuttingDown.set(true);
+        if (quitting) {
+            this.shuttingDown.set(true);
+            connectionMonitor.cancel();
+        }
         this.stop();
     }
 
     public void stop() {
-        Logger.getLogger(SSHTunnel.class.getName()).log(Level.INFO, String.format("[%s] Stopping secure tunnel", connectionId));
-        if (keepAliveTimer != null) {
-            keepAliveTimer.cancel();
-        }
-        if (connectionMonitorTimer != null) {
-            connectionMonitorTimer.cancel();
-        }
-        if (portForwardingMonitorTimer != null) {
-            portForwardingMonitorTimer.cancel();
-        }
+        synchronized (lifecycleLock) {
+            portForwardingEstablished = false;
+            Logger.getLogger(SSHTunnel.class.getName()).log(Level.INFO, String.format("[%s] Stopping secure tunnel", connectionId));
+            if (keepAliveTimer != null) {
+                keepAliveTimer.cancel();
+            }
+            if (connectionMonitorTimer != null) {
+                connectionMonitorTimer.cancel();
+            }
+            if (portForwardingMonitorTimer != null) {
+                portForwardingMonitorTimer.cancel();
+            }
 
-        if (session != null && session.isConnected()) {
-            session.disconnect();
+            if (session != null) {
+                session.disconnect();
+            }
         }
+    }
+
+    @Override
+    public boolean isForwardingEstablished() {
+        return portForwardingEstablished && isAuthenticated() && !shuttingDown.get();
     }
 
     // Delivery target for the reverse forward. JSch connects to this host for every
@@ -223,18 +274,18 @@ public class SSHTunnel implements ReconnectableTunnel {
         portForwardingEstablished = reverseOk && localOk;
         if (portForwardingEstablished) {
             Logger.getLogger(SSHTunnel.class.getName()).log(Level.INFO,
-                String.format("[%s] Port forwarding established: %s:2010 -> %s:%d, localhost:%d -> %s:%d",
-                    connectionId, server, REVERSE_FORWARD_HOST, app.getJettyPort(), app.getSSHPort(), hubHost, app.getHubPort()));
+                String.format("[%s] Port forwarding established: %s:%d -> %s:%d, localhost:%d -> %s:%d",
+                    connectionId, server, remoteProxyPort, REVERSE_FORWARD_HOST, app.getJettyPort(), app.getSSHPort(), hubHost, app.getHubPort()));
         }
     }
 
     private boolean establishReverseForward() {
         try {
-            session.setPortForwardingR(2010, REVERSE_FORWARD_HOST, app.getJettyPort());
+            session.setPortForwardingR(remoteProxyPort, REVERSE_FORWARD_HOST, app.getJettyPort());
             return true;
         } catch (JSchException ex) {
             Logger.getLogger(SSHTunnel.class.getName()).log(Level.SEVERE,
-                String.format("[%s] Could not setup port forwarding. Please make sure we can make an outbound connection to port 2010.", connectionId), ex);
+                String.format("[%s] Could not setup port forwarding. Please make sure we can make an outbound connection to port %d.", connectionId, remoteProxyPort), ex);
             return false;
         }
     }
@@ -254,7 +305,7 @@ public class SSHTunnel implements ReconnectableTunnel {
     /** Drops both forwards, ignoring ones that are not registered. */
     private void removePortForwarding() {
         try {
-            session.delPortForwardingR(2010);
+            session.delPortForwardingR(remoteProxyPort);
         } catch (Exception notRegistered) {
             Logger.getLogger(SSHTunnel.class.getName()).log(Level.FINE,
                 String.format("[%s] Reverse forward was not registered", connectionId));

--- a/src/test/java/com/testingbot/tunnel/ApiHostKeyFingerprintTest.java
+++ b/src/test/java/com/testingbot/tunnel/ApiHostKeyFingerprintTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import ssh.HostKeyPins;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Adoption of the tunnel server's host key fingerprint from the API response.
@@ -69,11 +70,16 @@ class ApiHostKeyFingerprintTest {
     }
 
     @Test
-    void unusableValueLeavesTheTunnelUnverifiedRatherThanFailing() {
+    void unusableValueIsFatalRatherThanConnectingUnverified() {
         App app = app();
 
-        app.adoptApiHostKeyFingerprint(node("ssh_fingerprint", "not-a-fingerprint"));
-
+        // The field being present at all means the service meant this connection to be verified,
+        // so a value that cannot be parsed is a bug or a rewrite on the path. Connecting anyway
+        // would hand over the account secret on exactly the occasion somebody interfered.
+        assertThatThrownBy(() -> app.adoptApiHostKeyFingerprint(
+                node("ssh_fingerprint", "not-a-fingerprint")))
+            .isInstanceOf(TunnelFailedException.class)
+            .hasMessageContaining("Refusing to connect unverified");
         assertThat(app.getSshHostKeyPins().isEmpty()).isTrue();
     }
 
@@ -81,9 +87,10 @@ class ApiHostKeyFingerprintTest {
     void md5FromTheApiIsRefused() {
         App app = app();
 
-        app.adoptApiHostKeyFingerprint(
-            node("ssh_fingerprint", "MD5:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff"));
-
+        assertThatThrownBy(() -> app.adoptApiHostKeyFingerprint(
+                node("ssh_fingerprint", "MD5:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff")))
+            .isInstanceOf(TunnelFailedException.class)
+            .hasMessageContaining("MD5");
         assertThat(app.getSshHostKeyPins().isEmpty()).isTrue();
     }
 

--- a/src/test/java/com/testingbot/tunnel/AppEmbeddedLifecycleTest.java
+++ b/src/test/java/com/testingbot/tunnel/AppEmbeddedLifecycleTest.java
@@ -1,0 +1,465 @@
+package com.testingbot.tunnel;
+
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.forward.AcceptAllForwardingFilter;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Authenticator;
+import java.net.InetAddress;
+import java.net.PasswordAuthentication;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * A whole tunnel booted inside another application's process.
+ *
+ * <p>{@link AppEmbeddedTest} covers the failure paths -- that a broken tunnel reports to its
+ * caller instead of calling {@code System.exit}. Nothing covered a tunnel that <em>works</em>
+ * embedded: every other test drives one component, and the command line is the only path that
+ * ever ran the whole of {@code boot()}. So the things that only go wrong when an App shares a
+ * JVM -- process-wide readiness, a JVM-wide authenticator, listeners and shutdown hooks that
+ * outlive their App, a second tunnel alongside the first -- had nowhere to fail.
+ *
+ * <p>The API is WireMock and the tunnel server is Apache MINA SSHD in this JVM, reached through
+ * the {@code createApi} and {@code createTunnel} seams. Two of the three startup checks are the
+ * real ones: the Selenium relay reaches a hub stand-in through the SSH local forward, and the
+ * reverse forward reaches the local proxy.
+ */
+class AppEmbeddedLifecycleTest {
+
+    private static final String KEY = "embedded_key";
+    private static final String SECRET = "embedded_secret";
+
+    private ServerSocket api;
+    /** One per App: in production every tunnel gets its own tunnel server. */
+    private final List<SshServer> sshServers = new ArrayList<>();
+    private Path keyDirectory;
+    private ServerSocket hub;
+    private ExecutorService pool;
+    private final List<App> started = new ArrayList<>();
+    private Authenticator authenticatorBefore;
+
+    @BeforeEach
+    void setUp(@TempDir Path tmp) throws Exception {
+        authenticatorBefore = Authenticator.getDefault();
+        TunnelMetrics.setTunnelUp(false);
+        pool = Executors.newCachedThreadPool();
+
+        api = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+        pool.submit(this::serveApi);
+
+        keyDirectory = tmp;
+
+        // What the Selenium relay's forward is delivered to: answers 200 to the HEAD that the
+        // forwarding self-test makes.
+        hub = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+        pool.submit(() -> {
+            while (!hub.isClosed()) {
+                try (Socket socket = hub.accept()) {
+                    BufferedReader in = new BufferedReader(new InputStreamReader(
+                            socket.getInputStream(), StandardCharsets.UTF_8));
+                    String line = in.readLine();
+                    while (line != null && !line.isEmpty()) {
+                        line = in.readLine();
+                    }
+                    OutputStream out = socket.getOutputStream();
+                    out.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                            .getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+                } catch (IOException closed) {
+                    return;
+                }
+            }
+        });
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        for (App app : started) {
+            assertThatCode(app::stop).doesNotThrowAnyException();
+        }
+        started.clear();
+        for (SshServer server : sshServers) {
+            server.stop(true);
+        }
+        sshServers.clear();
+        if (hub != null && !hub.isClosed()) {
+            hub.close();
+        }
+        if (api != null && !api.isClosed()) {
+            api.close();
+        }
+        if (pool != null) {
+            pool.shutdownNow();
+            Thread.interrupted();
+            pool.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        Authenticator.setDefault(authenticatorBefore);
+        TunnelMetrics.setTunnelUp(false);
+    }
+
+    /**
+     * A stand-in for the TestingBot API: creates the tunnel, answers polls, and -- the part that
+     * matters here -- performs the callback the startup self-test asks for.
+     *
+     * <p>{@code testProxy()} starts an ephemeral local server, posts its port, and expects the
+     * service to fetch it and echo what it served. Answering with a canned body would leave the
+     * third readiness check untested, which is the one that decides whether an embedded tunnel
+     * reports ready at all. This one really fetches. It dials the port directly rather than
+     * through TestingBot's own network, which is the single piece of the loop no in-process test
+     * can supply.
+     */
+    private void serveApi() {
+        while (!api.isClosed()) {
+            try (Socket socket = api.accept()) {
+                socket.setSoTimeout(10_000);
+                BufferedReader in = new BufferedReader(new InputStreamReader(
+                        socket.getInputStream(), StandardCharsets.UTF_8));
+                String requestLine = in.readLine();
+                if (requestLine == null) {
+                    continue;
+                }
+                int contentLength = 0;
+                String line;
+                while ((line = in.readLine()) != null && !line.isEmpty()) {
+                    if (line.toLowerCase(java.util.Locale.ROOT).startsWith("content-length:")) {
+                        contentLength = Integer.parseInt(line.split(":", 2)[1].trim());
+                    }
+                }
+                char[] body = new char[contentLength];
+                if (contentLength > 0) {
+                    in.read(body, 0, contentLength);
+                }
+                respondTo(socket, requestLine, new String(body));
+            } catch (Exception closed) {
+                if (api.isClosed()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    private void respondTo(Socket socket, String requestLine, String body) throws IOException {
+        String tunnel = "{\"id\":\"9001\",\"state\":\"READY\",\"ip\":\"127.0.0.1\"}";
+        if (requestLine.contains("/v1/tunnel/test")) {
+            String served = fetchCallback(formValue(body, "test_port"));
+            write(socket, 201, served);
+            return;
+        }
+        write(socket, 200, tunnel);
+    }
+
+    /** Fetches the ephemeral server testProxy() stood up, and returns what it served. */
+    private String fetchCallback(String port) {
+        if (port == null) {
+            return "";
+        }
+        try (Socket socket = new Socket("127.0.0.1", Integer.parseInt(port))) {
+            socket.setSoTimeout(10_000);
+            socket.getOutputStream().write(("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+                    + "Connection: close\r\n\r\n").getBytes(StandardCharsets.UTF_8));
+            socket.getOutputStream().flush();
+            String response = new String(socket.getInputStream().readAllBytes(),
+                    StandardCharsets.UTF_8);
+            int blank = response.indexOf("\r\n\r\n");
+            return blank < 0 ? "" : response.substring(blank + 4);
+        } catch (Exception unreachable) {
+            return "";
+        }
+    }
+
+    private static String formValue(String body, String name) {
+        for (String pair : body.split("&")) {
+            String[] parts = pair.split("=", 2);
+            if (parts.length == 2 && parts[0].equals(name)) {
+                return parts[1];
+            }
+        }
+        return null;
+    }
+
+    private static void write(Socket socket, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        OutputStream out = socket.getOutputStream();
+        out.write(("HTTP/1.1 " + status + " OK\r\nContent-Type: application/json\r\n"
+                + "Content-Length: " + bytes.length + "\r\nConnection: close\r\n\r\n")
+                .getBytes(StandardCharsets.UTF_8));
+        out.write(bytes);
+        out.flush();
+    }
+
+    /** An App wired to the in-process API and tunnel server, as an embedder would configure it. */
+    private SshServer newTunnelServer() throws IOException {
+        SshServer sshd = SshServer.setUpDefaultServer();
+        sshd.setHost("127.0.0.1");
+        sshd.setPort(0);
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(
+                keyDirectory.resolve("hostkey-" + sshServers.size() + ".ser")));
+        sshd.setPasswordAuthenticator((user, password, session) ->
+                KEY.equals(user) && SECRET.equals(password));
+        sshd.setForwardingFilter(AcceptAllForwardingFilter.INSTANCE);
+        sshd.start();
+        sshServers.add(sshd);
+        return sshd;
+    }
+
+    private App embeddedApp() throws IOException {
+        SshServer sshd = newTunnelServer();
+        // 2010 in production, where each tunnel server is its own machine. Here they share one.
+        int remoteProxyPort = TestPorts.free();
+        App app = new App() {
+            @Override
+            Api createApi() {
+                Api created = new Api(this);
+                created.setApiScheme("http");
+                created.setApiHost("127.0.0.1:" + api.getLocalPort());
+                return created;
+            }
+
+            @Override
+            ssh.SSHTunnel createTunnel(String serverIp) throws Exception {
+                return ssh.TestTunnels.connect(this, serverIp, sshd.getPort(), "127.0.0.1",
+                        remoteProxyPort);
+            }
+        };
+        app.setClientKey(KEY);
+        app.setClientSecret(SECRET);
+        app.setSeleniumPort(TestPorts.free());
+        app.setJettyPort(TestPorts.free());
+        app.setMetricsPort(TestPorts.free());
+        app.setHubPort(hub.getLocalPort());
+        started.add(app);
+        return app;
+    }
+
+    private App boot() throws Exception {
+        App app = embeddedApp();
+        app.boot();
+        return app;
+    }
+
+    /** GETs a path on an App's metrics port and returns the status code. */
+    private static int probe(App app, String path) throws Exception {
+        try (Socket socket = new Socket("127.0.0.1", app.getMetricsPort())) {
+            socket.setSoTimeout(10_000);
+            socket.getOutputStream().write(("GET " + path + " HTTP/1.1\r\nHost: localhost\r\n"
+                    + "Connection: close\r\n\r\n").getBytes(StandardCharsets.UTF_8));
+            socket.getOutputStream().flush();
+            BufferedReader in = new BufferedReader(new InputStreamReader(
+                    socket.getInputStream(), StandardCharsets.UTF_8));
+            String status = in.readLine();
+            return status == null ? -1 : Integer.parseInt(status.split(" ")[1]);
+        }
+    }
+
+    private static boolean portIsFree(int port) {
+        try (ServerSocket probe = new ServerSocket(port, 1, InetAddress.getLoopbackAddress())) {
+            return true;
+        } catch (IOException stillBound) {
+            return false;
+        }
+    }
+
+    @Test
+    void aTunnelBootsAndReportsItselfReady() throws Exception {
+        App app = boot();
+
+        assertThat(app.isReady())
+                .as("the self-test's checks pass against the in-process hub and proxy")
+                .isTrue();
+        assertThat(probe(app, "/readyz")).isEqualTo(200);
+        assertThat(probe(app, "/healthz")).isEqualTo(200);
+    }
+
+    @Test
+    void stoppingReleasesEveryListenerItBound() throws Exception {
+        App app = boot();
+        int metricsPort = app.getMetricsPort();
+        int proxyPort = app.getJettyPort();
+        int seleniumPort = app.getSeleniumPort();
+
+        app.stop();
+
+        // A host application that runs a tunnel per job gets the ports back, or the next job
+        // cannot bind them.
+        Await.until("the metrics port to be released", () -> portIsFree(metricsPort));
+        Await.until("the local proxy port to be released", () -> portIsFree(proxyPort));
+        Await.until("the Selenium relay port to be released", () -> portIsFree(seleniumPort));
+        assertThat(app.isReady()).isFalse();
+    }
+
+    @Test
+    void aTunnelPerJobCanBeBootedAgainInTheSameProcess() throws Exception {
+        App first = boot();
+        assertThat(first.isReady()).isTrue();
+        first.stop();
+
+        App second = boot();
+
+        assertThat(second.isReady())
+                .as("nothing the first tunnel installed may stop the second from working")
+                .isTrue();
+        assertThat(probe(second, "/readyz")).isEqualTo(200);
+    }
+
+    @Test
+    void twoTunnelsInOneProcessReportTheirOwnReadiness() throws Exception {
+        // The reason readiness is per App. Both endpoints answered from one process-wide gauge,
+        // so a host running two tunnels saw them as a single tunnel -- and stopping either one
+        // reported the other as not ready.
+        App first = boot();
+        App second = boot();
+        assertThat(probe(first, "/readyz")).isEqualTo(200);
+        assertThat(probe(second, "/readyz")).isEqualTo(200);
+
+        first.stop();
+
+        assertThat(first.isReady()).isFalse();
+        assertThat(second.isReady())
+                .as("stopping one tunnel must not report the other as down")
+                .isTrue();
+        assertThat(probe(second, "/readyz")).isEqualTo(200);
+    }
+
+    @Test
+    void stoppingPutsBackTheAuthenticatorItReplaced() throws Exception {
+        // Authenticator.setDefault is JVM-wide with no other hook, so a tunnel that does not put
+        // back what it found leaves a host application's own credentials answered by ours.
+        Authenticator hostApplications = new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication("host", "app".toCharArray());
+            }
+        };
+        Authenticator.setDefault(hostApplications);
+
+        App app = embeddedApp();
+        app.setProxy("127.0.0.1:1");
+        app.setProxyAuth("tunnel-user:tunnel-password");
+        assertThat(Authenticator.getDefault()).isNotSameAs(hostApplications);
+
+        app.stop();
+
+        assertThat(Authenticator.getDefault()).isSameAs(hostApplications);
+    }
+
+    @Test
+    void configuringProxyCredentialsTwiceDoesNotStackAuthenticators() {
+        Authenticator hostApplications = Authenticator.getDefault();
+
+        App app = new App();
+        app.setProxy("127.0.0.1:1");
+        app.setProxyAuth("user:one");
+        Authenticator afterFirst = Authenticator.getDefault();
+        app.setProxyAuth("user:two");
+
+        assertThat(Authenticator.getDefault()).isNotSameAs(afterFirst);
+        app.stop();
+        assertThat(Authenticator.getDefault())
+                .as("each call replaces the last, so stop() gets back to where it started")
+                .isSameAs(hostApplications);
+    }
+
+    @Test
+    void awaitReadyReturnsOnceTheTunnelIsForwarding() throws Exception {
+        App app = boot();
+
+        assertThat(app.awaitReady(java.time.Duration.ofSeconds(10)))
+                .as("boot() returns when the tunnel is created; this is when it can carry traffic")
+                .isTrue();
+        assertThat(app.getSetupFailure()).isNull();
+    }
+
+    @Test
+    void awaitReadyGivesUpImmediatelyOnATunnelThatFailed() throws Exception {
+        App app = embeddedApp();
+        app.setupFailed("the tunnel server never came up", 1);
+
+        long started = System.currentTimeMillis();
+        assertThat(app.awaitReady(java.time.Duration.ofSeconds(30))).isFalse();
+
+        assertThat(System.currentTimeMillis() - started)
+                .as("nothing is still trying, so waiting out the clock only delays the caller")
+                .isLessThan(5_000);
+        assertThat(app.getSetupFailure()).contains("never came up");
+    }
+
+    @Test
+    void awaitReadyTimesOutRatherThanBlockingForever() throws Exception {
+        App app = embeddedApp();
+
+        assertThat(app.awaitReady(java.time.Duration.ofMillis(200))).isFalse();
+    }
+
+    @Test
+    void stoppingForgetsTheSocksCredentialsItRegistered() throws Exception {
+        // The SOCKS registry is static too, because the JDK's SOCKS client offers no other hook.
+        // A stopped tunnel's password went on being offered for the proxy it named -- to the
+        // host application's own connections to that same proxy.
+        // --proxy-testingbot rather than --proxy, so this exercises the SOCKS registry alone:
+        // --proxy-userpwd installs a second, separate authenticator that would answer the probe
+        // below whatever the registry says.
+        App app = embeddedApp();
+        app.setControlProxy("socks5://127.0.0.1:1080");
+        app.setControlProxyAuth("socks-user:socks-password");
+        ControlPlaneClients.forApp(app).build().close();
+
+        assertThat(socksPasswordFor("127.0.0.1", 1080))
+                .as("registered while the tunnel is configured")
+                .isNotNull();
+
+        app.stop();
+
+        assertThat(socksPasswordFor("127.0.0.1", 1080))
+                .as("and forgotten once it is stopped")
+                .isNull();
+    }
+
+    /** Asks the JVM's default authenticator what it would give a SOCKS proxy. */
+    private static PasswordAuthentication socksPasswordFor(String host, int port) throws Exception {
+        return Authenticator.requestPasswordAuthentication(
+                host, InetAddress.getByName(host), port, "SOCKS5", "SOCKS authentication",
+                null, null, Authenticator.RequestorType.PROXY);
+    }
+
+    @Test
+    void bootingDoesNotLeaveThreadsBehindAfterStop() throws Exception {
+        App app = boot();
+
+        app.stop();
+
+        // Named threads this App owns: the SSH timers, the reconnect scheduler and the self-test
+        // retry. A host process is long-lived, so one leaked timer per job accumulates.
+        Await.until("the tunnel's own threads to go away", () -> {
+            for (Thread thread : Thread.getAllStackTraces().keySet()) {
+                String name = thread.getName();
+                if (thread.isAlive() && (name.startsWith("KeepAlive-")
+                        || name.startsWith("ConnectionMonitor-")
+                        || name.startsWith("PortForwardingMonitor-")
+                        || name.startsWith("Reconnect-")
+                        || name.startsWith("SelfTestRetry-"))) {
+                    return false;
+                }
+            }
+            return true;
+        });
+    }
+}

--- a/src/test/java/com/testingbot/tunnel/AppEmbeddedLifecycleTest.java
+++ b/src/test/java/com/testingbot/tunnel/AppEmbeddedLifecycleTest.java
@@ -73,9 +73,9 @@ class AppEmbeddedLifecycleTest {
         hub = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
         pool.submit(() -> {
             while (!hub.isClosed()) {
-                try (Socket socket = hub.accept()) {
-                    BufferedReader in = new BufferedReader(new InputStreamReader(
-                            socket.getInputStream(), StandardCharsets.UTF_8));
+                try (Socket socket = hub.accept();
+                     BufferedReader in = new BufferedReader(new InputStreamReader(
+                             socket.getInputStream(), StandardCharsets.UTF_8))) {
                     String line = in.readLine();
                     while (line != null && !line.isEmpty()) {
                         line = in.readLine();
@@ -129,10 +129,10 @@ class AppEmbeddedLifecycleTest {
      */
     private void serveApi() {
         while (!api.isClosed()) {
-            try (Socket socket = api.accept()) {
+            try (Socket socket = api.accept();
+                 BufferedReader in = new BufferedReader(new InputStreamReader(
+                         socket.getInputStream(), StandardCharsets.UTF_8))) {
                 socket.setSoTimeout(10_000);
-                BufferedReader in = new BufferedReader(new InputStreamReader(
-                        socket.getInputStream(), StandardCharsets.UTF_8));
                 String requestLine = in.readLine();
                 if (requestLine == null) {
                     continue;
@@ -258,13 +258,13 @@ class AppEmbeddedLifecycleTest {
 
     /** GETs a path on an App's metrics port and returns the status code. */
     private static int probe(App app, String path) throws Exception {
-        try (Socket socket = new Socket("127.0.0.1", app.getMetricsPort())) {
+        try (Socket socket = new Socket("127.0.0.1", app.getMetricsPort());
+             BufferedReader in = new BufferedReader(new InputStreamReader(
+                     socket.getInputStream(), StandardCharsets.UTF_8))) {
             socket.setSoTimeout(10_000);
             socket.getOutputStream().write(("GET " + path + " HTTP/1.1\r\nHost: localhost\r\n"
                     + "Connection: close\r\n\r\n").getBytes(StandardCharsets.UTF_8));
             socket.getOutputStream().flush();
-            BufferedReader in = new BufferedReader(new InputStreamReader(
-                    socket.getInputStream(), StandardCharsets.UTF_8));
             String status = in.readLine();
             return status == null ? -1 : Integer.parseInt(status.split(" ")[1]);
         }

--- a/src/test/java/com/testingbot/tunnel/ControlPlaneClients.java
+++ b/src/test/java/com/testingbot/tunnel/ControlPlaneClients.java
@@ -1,0 +1,21 @@
+package com.testingbot.tunnel;
+
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+
+/**
+ * Test-only access to the control-plane HTTP client.
+ *
+ * <p>{@code Api.controlPlaneBuilder} is package-private, and the tests that need to drive it --
+ * an upstream proxy demanding Kerberos, say -- live elsewhere. This exposes it without widening
+ * the production API.
+ */
+public final class ControlPlaneClients {
+
+    private ControlPlaneClients() {
+    }
+
+    /** The client the API calls, {@code --doctor} and the startup self-test all use. */
+    public static HttpClientBuilder forApp(App app) {
+        return Api.controlPlaneBuilder(app);
+    }
+}

--- a/src/test/java/com/testingbot/tunnel/EnvOptionsTest.java
+++ b/src/test/java/com/testingbot/tunnel/EnvOptionsTest.java
@@ -79,6 +79,32 @@ class EnvOptionsTest {
     }
 
     @Test
+    void explicitFalseInConfigSuppressesTrueFromTheEnvironment(
+            @org.junit.jupiter.api.io.TempDir java.nio.file.Path tmp) throws Exception {
+        options.addOption(null, "shared", false, "shared tunnel");
+        java.nio.file.Path config = tmp.resolve("tunnel.conf");
+        java.nio.file.Files.writeString(config, "shared=false\nnobump=false\n");
+        ConfigFile.Expansion fromConfig = ConfigFile.expandWithSources(
+                new String[]{"--config", config.toString()}, options);
+        String[] expanded = EnvOptions.expand(fromConfig, options,
+                Map.of("TESTINGBOT_SHARED", "true", "TESTINGBOT_NOBUMP", "true"));
+        var parsed = new org.apache.commons.cli.PosixParser().parse(options, expanded);
+        assertThat(parsed.hasOption("shared")).isFalse();
+        assertThat(parsed.hasOption("nobump")).isFalse();
+    }
+
+    @Test
+    void commandLineTrueStillOverridesConfigFalse(
+            @org.junit.jupiter.api.io.TempDir java.nio.file.Path tmp) throws Exception {
+        java.nio.file.Path config = tmp.resolve("tunnel.conf");
+        java.nio.file.Files.writeString(config, "nobump=false\n");
+        ConfigFile.Expansion fromConfig = ConfigFile.expandWithSources(
+                new String[]{"--config", config.toString(), "--nobump"}, options);
+        assertThat(EnvOptions.expand(fromConfig, options,
+                Map.of("TESTINGBOT_NOBUMP", "false"))).contains("--nobump");
+    }
+
+    @Test
     void emptyOrBlankValues_areIgnored() {
         assertThat(EnvOptions.expand(new String[]{}, options,
                 Map.of("TESTINGBOT_SE_PORT", "   "))).isEmpty();

--- a/src/test/java/com/testingbot/tunnel/HealthEndpointsTest.java
+++ b/src/test/java/com/testingbot/tunnel/HealthEndpointsTest.java
@@ -31,12 +31,14 @@ class HealthEndpointsTest {
     }
 
     private InsightServer insightServer;
+    /** The App the endpoints answer for: readiness is per tunnel, not per process. */
+    private App app;
 
     @BeforeEach
     void setUp() throws Exception {
         TunnelMetrics.setTunnelUp(false);
         metricsPort = findFreePort();
-        App app = new App();
+        app = new App();
         app.setClientKey("test_key");
         app.setClientSecret("test_secret");
         app.setMetricsPort(metricsPort);
@@ -88,18 +90,20 @@ class HealthEndpointsTest {
 
     @Test
     void readyz_is200OnceTheTunnelIsUp() throws Exception {
-        TunnelMetrics.setTunnelUp(true);
+        // Through the App, which is what the tunnel itself does. The gauge is mirrored from
+        // here, not read by the endpoint: two tunnels in one process each answer for their own.
+        app.setReady(true);
 
         assertThat(get("/readyz")).isEqualTo("200|{\"status\":\"ready\"}");
     }
 
     @Test
     void readyz_dropsBackTo503WhenTheConnectionIsLost() throws Exception {
-        TunnelMetrics.setTunnelUp(true);
+        app.setReady(true);
         assertThat(get("/readyz")).startsWith("200");
 
-        // What CustomConnectionMonitor.connectionLost() does.
-        TunnelMetrics.setTunnelUp(false);
+        // What CustomConnectionMonitor.connectionLost() does, via ReconnectHost.
+        app.setReady(false);
 
         assertThat(get("/readyz")).isEqualTo("503|{\"status\":\"not_ready\"}");
         // ...while liveness stays up, so the process is not killed mid-recovery.
@@ -132,10 +136,10 @@ class HealthEndpointsTest {
 
     @Test
     void readinessProbe_exitCodeFollowsTheEndpoint() {
-        TunnelMetrics.setTunnelUp(true);
+        app.setReady(true);
         assertThat(ReadinessProbe.probe("127.0.0.1", metricsPort, 2_000)).isZero();
 
-        TunnelMetrics.setTunnelUp(false);
+        app.setReady(false);
         assertThat(ReadinessProbe.probe("127.0.0.1", metricsPort, 2_000)).isEqualTo(1);
     }
 

--- a/src/test/java/com/testingbot/tunnel/OptionHandlingTest.java
+++ b/src/test/java/com/testingbot/tunnel/OptionHandlingTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -223,6 +224,52 @@ class OptionHandlingTest {
         assertThatThrownBy(() -> withOptions("--localhost-policy", "maybe"))
                 .isInstanceOf(ParseException.class)
                 .hasMessageContaining("Expected allow or deny");
+    }
+
+    @Test
+    void sshHostKeyPinsComeFromTheCommandLine() throws Exception {
+        // The recourse on a network where the API response itself could be rewritten: a pin
+        // established out of band, which the API is then not allowed to replace.
+        String first = ssh.HostKeyPins.displayFingerprint("key-one".getBytes(UTF_8));
+        String second = ssh.HostKeyPins.displayFingerprint("key-two".getBytes(UTF_8));
+
+        App app = withOptions("--ssh-host-key", first + "," + second);
+
+        assertThat(app.getSshHostKeyPins().displayValues()).containsExactly(first, second);
+    }
+
+    @Test
+    void repeatingSshHostKeyAddsRatherThanReplaces() throws Exception {
+        String first = ssh.HostKeyPins.displayFingerprint("key-one".getBytes(UTF_8));
+        String second = ssh.HostKeyPins.displayFingerprint("key-two".getBytes(UTF_8));
+
+        App app = withOptions("--ssh-host-key", first, "--ssh-host-key", second);
+
+        assertThat(app.getSshHostKeyPins().displayValues()).containsExactly(first, second);
+    }
+
+    @Test
+    void anUnusableSshHostKeyIsRefusedRatherThanIgnored() {
+        // Accepting it would leave a pin that matches nothing, or none at all -- either way the
+        // operator believes the server is verified when it is not.
+        assertThatThrownBy(() -> withOptions("--ssh-host-key", "not-a-fingerprint"))
+                .isInstanceOf(ParseException.class)
+                .hasMessageContaining("--ssh-host-key");
+    }
+
+    @Test
+    void sshHostKeyPolicyAcceptsOnlyWarnOrRequire() throws Exception {
+        assertThat(withOptions("--ssh-host-key-policy", "require").requiresVerifiedSshHostKey())
+                .isTrue();
+        assertThat(withOptions("--ssh-host-key-policy", "WARN").requiresVerifiedSshHostKey())
+                .isFalse();
+        assertThat(new App().requiresVerifiedSshHostKey())
+                .as("still the default, because the service does not publish fingerprints yet")
+                .isFalse();
+
+        assertThatThrownBy(() -> withOptions("--ssh-host-key-policy", "maybe"))
+                .isInstanceOf(ParseException.class)
+                .hasMessageContaining("Expected warn or require");
     }
 
     @Test

--- a/src/test/java/com/testingbot/tunnel/SelfTestRetryTest.java
+++ b/src/test/java/com/testingbot/tunnel/SelfTestRetryTest.java
@@ -1,0 +1,124 @@
+package com.testingbot.tunnel;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A startup self-test that failed once must be tried again.
+ *
+ * <p>Readiness is gated on the self-test, and its checks can fail for reasons that pass a moment
+ * later -- the hub still refusing connections on a tunnel server that has only just booted. With
+ * nothing retrying it, such a tunnel stayed at 503 for the life of a perfectly healthy SSH
+ * session: the reconnect path re-runs everything, but only when the connection actually drops.
+ */
+class SelfTestRetryTest {
+
+    @TempDir
+    Path tempDir;
+
+    private App app;
+
+    @BeforeEach
+    void setUp() {
+        TunnelMetrics.setTunnelUp(false);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (app != null) {
+            app.cancelSelfTestRetry();
+        }
+        TunnelMetrics.setTunnelUp(false);
+    }
+
+    /** An App whose self-test fails the first {@code failures} times it is asked. */
+    private static class RetryingApp extends App {
+        private final AtomicInteger calls = new AtomicInteger();
+        private final int failures;
+        private volatile boolean forwarding = true;
+
+        RetryingApp(int failures) {
+            this.failures = failures;
+            this.selfTestRetryIntervalMs = 25;
+        }
+
+        @Override
+        boolean selfTest() {
+            return calls.incrementAndGet() > failures;
+        }
+
+        @Override
+        boolean tunnelIsForwarding() {
+            return forwarding;
+        }
+    }
+
+    @Test
+    void aTransientFailureBecomesReadyOnRetry() throws Exception {
+        Path readyFile = tempDir.resolve("tunnel.ready");
+        RetryingApp retrying = new RetryingApp(2);
+        app = retrying;
+        retrying.setReadyFile(readyFile.toString());
+
+        retrying.scheduleSelfTestRetry();
+
+        Await.until("the retried self-test to report the tunnel ready", TunnelMetrics::isTunnelUp);
+        assertThat(Files.exists(readyFile))
+                .as("--readyfile follows the same gate as /readyz")
+                .isTrue();
+    }
+
+    @Test
+    void retryingStopsOnceItSucceeds() throws Exception {
+        RetryingApp retrying = new RetryingApp(1);
+        app = retrying;
+
+        retrying.scheduleSelfTestRetry();
+        Await.until("the retry to succeed", TunnelMetrics::isTunnelUp);
+
+        int callsAtSuccess = retrying.calls.get();
+        // Asserting that nothing further happens has no condition to poll for: several retry
+        // intervals have to pass before the absence means anything.
+        Thread.sleep(150);
+        assertThat(retrying.calls.get())
+                .as("the timer is cancelled once the tunnel is ready")
+                .isEqualTo(callsAtSuccess);
+    }
+
+    @Test
+    void aDroppedConnectionIsLeftToTheReconnectMonitor() throws Exception {
+        RetryingApp retrying = new RetryingApp(0);
+        app = retrying;
+        retrying.forwarding = false;
+
+        retrying.scheduleSelfTestRetry();
+        Thread.sleep(150);
+
+        assertThat(retrying.calls.get())
+                .as("no point testing a tunnel whose SSH session is down; that path rebuilds it")
+                .isZero();
+        assertThat(TunnelMetrics.isTunnelUp()).isFalse();
+    }
+
+    @Test
+    void retryingGivesUpRatherThanRunningForever() throws Exception {
+        RetryingApp retrying = new RetryingApp(Integer.MAX_VALUE);
+        app = retrying;
+
+        retrying.scheduleSelfTestRetry();
+
+        Await.until("the retry loop to stop after its bounded attempts",
+                () -> retrying.calls.get() >= App.SELF_TEST_RETRY_ATTEMPTS);
+        Thread.sleep(150);
+        assertThat(retrying.calls.get()).isEqualTo(App.SELF_TEST_RETRY_ATTEMPTS);
+        assertThat(TunnelMetrics.isTunnelUp()).isFalse();
+    }
+}

--- a/src/test/java/com/testingbot/tunnel/integration/NegotiateProxyTest.java
+++ b/src/test/java/com/testingbot/tunnel/integration/NegotiateProxyTest.java
@@ -427,4 +427,35 @@ class NegotiateProxyTest {
                 .as("a ticket for another service must not verify")
                 .isEmpty();
     }
+
+    @Test
+    void theApiClientIsAcceptedByTheProxy() throws Exception {
+        // The path that runs before any of the others: creating the tunnel, polling it and
+        // tearing it down. It installed username/password credentials and nothing else, so on a
+        // proxy demanding Negotiate it returned 407 and the tunnel never started -- while SSH
+        // and browser traffic, which have their own Negotiate support, would have been fine.
+        startUpstream();
+
+        App app = new App();
+        app.setClientKey("test_key");
+        app.setClientSecret("test_secret");
+        app.setProxy(PROXY_HOST + ":" + upstream.getLocalPort());
+        app.setProxyAuthScheme("negotiate");
+        app.setKrb5KeyTab(clientKeyTab.toAbsolutePath().toString());
+        app.setKrb5Principal(CLIENT_PRINCIPAL + "@" + REALM);
+
+        try (org.apache.hc.client5.http.impl.classic.CloseableHttpClient client =
+                     com.testingbot.tunnel.ControlPlaneClients.forApp(app).build()) {
+            String body = client.execute(
+                    new org.apache.hc.client5.http.classic.methods.HttpGet("http://example.com/"),
+                    response -> org.apache.hc.core5.http.io.entity.EntityUtils.toString(
+                            response.getEntity()));
+
+            assertThat(body)
+                    .as("the proxy answers 200 only for a token it could verify")
+                    .contains("negotiated-ok");
+        }
+
+        assertThat(verifiedClients).contains(CLIENT_PRINCIPAL + "@" + REALM);
+    }
 }

--- a/src/test/java/com/testingbot/tunnel/integration/PacAbsoluteFormTest.java
+++ b/src/test/java/com/testingbot/tunnel/integration/PacAbsoluteFormTest.java
@@ -56,9 +56,9 @@ class PacAbsoluteFormTest {
                 try {
                     Socket accepted = peer.accept();
                     pool.submit(() -> {
-                        try (Socket socket = accepted) {
-                            BufferedReader in = new BufferedReader(new InputStreamReader(
-                                    socket.getInputStream(), StandardCharsets.UTF_8));
+                        try (Socket socket = accepted;
+                             BufferedReader in = new BufferedReader(new InputStreamReader(
+                                     socket.getInputStream(), StandardCharsets.UTF_8))) {
                             String requestLine = in.readLine();
                             String line;
                             while ((line = in.readLine()) != null && !line.isEmpty()) {
@@ -130,14 +130,14 @@ class PacAbsoluteFormTest {
     }
 
     private String proxyGet(String host, String pathQuery) throws Exception {
-        try (Socket socket = new Socket("127.0.0.1", proxyPort)) {
+        try (Socket socket = new Socket("127.0.0.1", proxyPort);
+             BufferedReader reader = new BufferedReader(new InputStreamReader(
+                     socket.getInputStream(), StandardCharsets.UTF_8))) {
             socket.setSoTimeout(10_000);
             String request = "GET http://" + host + pathQuery + " HTTP/1.1\r\n"
                     + "Host: " + host + "\r\nConnection: close\r\n\r\n";
             socket.getOutputStream().write(request.getBytes(StandardCharsets.UTF_8));
             socket.getOutputStream().flush();
-            BufferedReader reader = new BufferedReader(new InputStreamReader(
-                    socket.getInputStream(), StandardCharsets.UTF_8));
             StringBuilder all = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {

--- a/src/test/java/com/testingbot/tunnel/integration/PacAbsoluteFormTest.java
+++ b/src/test/java/com/testingbot/tunnel/integration/PacAbsoluteFormTest.java
@@ -1,0 +1,198 @@
+package com.testingbot.tunnel.integration;
+
+import com.testingbot.tunnel.App;
+import com.testingbot.tunnel.HttpProxy;
+import com.testingbot.tunnel.TestPorts;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The request line has to follow the route that was actually chosen, not the one {@code --proxy}
+ * describes.
+ *
+ * <p>{@link UpstreamProxyAbsoluteFormTest} fixed origin-form leaking to a static upstream proxy,
+ * but the test for it asked {@code --proxy} whether a proxy was in use. A proxy named only by a
+ * PAC file was therefore still sent origin-form -- the same 400 from Squid, on the path where
+ * nothing looked -- and a PAC file answering DIRECT while {@code --proxy} was configured sent
+ * absolute-form straight at an origin server, which is not required to understand it.
+ */
+class PacAbsoluteFormTest {
+
+    @TempDir
+    Path tempDir;
+
+    private ServerSocket peer;
+    private ExecutorService pool;
+    private Thread acceptor;
+    private HttpProxy httpProxy;
+    private int proxyPort;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Stands in for either end of the decision: a forward proxy or an origin server. Both
+        // answer 200 and echo the request line, so the test can see which form it was given.
+        peer = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+        pool = Executors.newCachedThreadPool();
+        acceptor = new Thread(() -> {
+            while (!peer.isClosed()) {
+                try {
+                    Socket accepted = peer.accept();
+                    pool.submit(() -> {
+                        try (Socket socket = accepted) {
+                            BufferedReader in = new BufferedReader(new InputStreamReader(
+                                    socket.getInputStream(), StandardCharsets.UTF_8));
+                            String requestLine = in.readLine();
+                            String line;
+                            while ((line = in.readLine()) != null && !line.isEmpty()) {
+                                // drain headers
+                            }
+                            byte[] body = ("SAW=" + requestLine).getBytes(StandardCharsets.UTF_8);
+                            OutputStream out = socket.getOutputStream();
+                            out.write(("HTTP/1.1 200 OK\r\nContent-Length: " + body.length
+                                    + "\r\nConnection: close\r\n\r\n").getBytes(StandardCharsets.UTF_8));
+                            out.write(body);
+                            out.flush();
+                        } catch (Exception ignored) {
+                            // client went away; nothing useful to do
+                        }
+                    });
+                } catch (IOException closed) {
+                    return;
+                }
+            }
+        });
+        acceptor.setDaemon(true);
+        acceptor.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (httpProxy != null) {
+            httpProxy.stop();
+        }
+        if (acceptor != null) {
+            acceptor.interrupt();
+        }
+        if (peer != null && !peer.isClosed()) {
+            peer.close();
+        }
+        if (pool != null) {
+            pool.shutdownNow();
+            Thread.interrupted();
+            pool.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    private void startTunnelProxy(String pacScript, String staticProxy) throws Exception {
+        Path pac = tempDir.resolve("routing.pac");
+        Files.writeString(pac, pacScript);
+
+        proxyPort = TestPorts.free();
+        App app = new App();
+        app.setJettyPort(proxyPort);
+        app.setClientKey("test_key");
+        app.setClientSecret("test_secret");
+        if (staticProxy != null) {
+            app.setProxy(staticProxy);
+        }
+        app.setPacLocal(pac.toString());
+        httpProxy = new HttpProxy(app);
+        waitForPort(proxyPort);
+    }
+
+    private static void waitForPort(int port) throws Exception {
+        for (int i = 0; i < 100; i++) {
+            try (Socket s = new Socket("127.0.0.1", port)) {
+                return;
+            } catch (IOException retry) {
+                Thread.sleep(50);
+            }
+        }
+        throw new IllegalStateException("Proxy did not start on port " + port);
+    }
+
+    private String proxyGet(String host, String pathQuery) throws Exception {
+        try (Socket socket = new Socket("127.0.0.1", proxyPort)) {
+            socket.setSoTimeout(10_000);
+            String request = "GET http://" + host + pathQuery + " HTTP/1.1\r\n"
+                    + "Host: " + host + "\r\nConnection: close\r\n\r\n";
+            socket.getOutputStream().write(request.getBytes(StandardCharsets.UTF_8));
+            socket.getOutputStream().flush();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(
+                    socket.getInputStream(), StandardCharsets.UTF_8));
+            StringBuilder all = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                all.append(line).append('\n');
+            }
+            return all.toString();
+        }
+    }
+
+    @Test
+    void aProxyNamedOnlyByPacStillGetsAbsoluteForm() throws Exception {
+        // The lenient query string is what makes this visible: jetty-client leaves getURI() null
+        // for it, so nothing rewrites the target and the form is whatever this code decided.
+        startTunnelProxy("function FindProxyForURL(url, host) {"
+                + " return \"PROXY 127.0.0.1:" + peer.getLocalPort() + "\"; }", null);
+
+        String response = proxyGet("example.test", "/?a=1&b={json}");
+
+        assertThat(response)
+                .as("a PAC-selected proxy is still a proxy, and RFC 9112 3.2.2 applies to it")
+                .contains("SAW=GET http://example.test/?a=1&b={json} HTTP/1.1");
+    }
+
+    @Test
+    void aPacDirectAnswerSendsOriginFormEvenWhenAStaticProxyIsConfigured() throws Exception {
+        // --proxy is configured but the file overrules it for this host, so the request is
+        // addressed to the origin. An origin server may reject an absolute-form target.
+        startTunnelProxy("function FindProxyForURL(url, host) { return \"DIRECT\"; }",
+                "127.0.0.1:1");
+
+        String response = proxyGet("127.0.0.1:" + peer.getLocalPort(), "/?a=1&b={json}");
+
+        assertThat(response).contains("SAW=GET /?a=1&b={json} HTTP/1.1");
+    }
+
+    @Test
+    void thePacFileSeesThePathTheRequestActuallyUses() throws Exception {
+        // The routing method used to substitute "scheme://host:port/" for every request, so a
+        // rule written on the path matched nothing here while --pac-test, which evaluates the
+        // URL it is given, said it did. A file could be validated and then not followed.
+        startTunnelProxy("function FindProxyForURL(url, host) {"
+                + " if (shExpMatch(url, \"http://*/private*\"))"
+                + "   return \"PROXY 127.0.0.1:" + peer.getLocalPort() + "\";"
+                + " return \"DIRECT\"; }", null);
+
+        String proxied = proxyGet("example.test", "/private/thing");
+
+        assertThat(proxied)
+                .as("the rule matches the real path, so this goes through the named proxy")
+                .contains("SAW=GET http://example.test/private/thing HTTP/1.1");
+
+        String direct = proxyGet("127.0.0.1:" + peer.getLocalPort(), "/public/thing");
+
+        assertThat(direct)
+                .as("a path the rule does not match is dialled directly")
+                .contains("SAW=GET /public/thing HTTP/1.1");
+    }
+}

--- a/src/test/java/com/testingbot/tunnel/integration/ProxyCredentialEndpointScopeTest.java
+++ b/src/test/java/com/testingbot/tunnel/integration/ProxyCredentialEndpointScopeTest.java
@@ -65,9 +65,9 @@ class ProxyCredentialEndpointScopeTest {
         ServerSocket server = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
         Thread acceptor = new Thread(() -> {
             while (!server.isClosed()) {
-                try (Socket socket = server.accept()) {
-                    BufferedReader in = new BufferedReader(new InputStreamReader(
-                            socket.getInputStream(), StandardCharsets.UTF_8));
+                try (Socket socket = server.accept();
+                     BufferedReader in = new BufferedReader(new InputStreamReader(
+                             socket.getInputStream(), StandardCharsets.UTF_8))) {
                     List<String> head = new ArrayList<>();
                     String line;
                     while ((line = in.readLine()) != null && !line.isEmpty()) {
@@ -124,12 +124,13 @@ class ProxyCredentialEndpointScopeTest {
     }
 
     private void send(String requestHead, List<String> expectRecordedIn) throws Exception {
-        try (Socket socket = new Socket("127.0.0.1", tunnelPort)) {
+        try (Socket socket = new Socket("127.0.0.1", tunnelPort);
+             BufferedReader in = new BufferedReader(new InputStreamReader(
+                     socket.getInputStream(), StandardCharsets.UTF_8))) {
             socket.setSoTimeout(10_000);
             socket.getOutputStream().write(requestHead.getBytes(StandardCharsets.UTF_8));
             socket.getOutputStream().flush();
-            new BufferedReader(new InputStreamReader(
-                    socket.getInputStream(), StandardCharsets.UTF_8)).readLine();
+            in.readLine();
             Await.until("the upstream to record the request head",
                     () -> !expectRecordedIn.isEmpty());
         }

--- a/src/test/java/com/testingbot/tunnel/integration/ProxyCredentialEndpointScopeTest.java
+++ b/src/test/java/com/testingbot/tunnel/integration/ProxyCredentialEndpointScopeTest.java
@@ -1,0 +1,218 @@
+package com.testingbot.tunnel.integration;
+
+import com.testingbot.tunnel.App;
+import com.testingbot.tunnel.Await;
+import com.testingbot.tunnel.HttpProxy;
+import com.testingbot.tunnel.TestPorts;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code --proxy-userpwd} belongs to one endpoint, not to one hostname.
+ *
+ * <p>The CONNECT and WebSocket paths asked whether the chosen upstream's <em>host</em> matched
+ * {@code --proxy}, which on the loopback interface every peer does. A PAC file naming
+ * {@code 127.0.0.1} on any other port therefore received the customer's proxy password -- and
+ * another service or another local user can own that port. The plain-HTTP path already withheld
+ * it, so the same tunnel's answer depended on the scheme.
+ */
+class ProxyCredentialEndpointScopeTest {
+
+    private static final String USER_PASSWORD = "audit-user:audit-password";
+
+    @TempDir
+    Path tempDir;
+
+    private final List<String> configuredProxyLog = new CopyOnWriteArrayList<>();
+    private final List<String> pacProxyLog = new CopyOnWriteArrayList<>();
+
+    private ServerSocket configuredProxy;
+    private ServerSocket pacProxy;
+    private HttpProxy tunnel;
+    private int tunnelPort;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (tunnel != null) {
+            tunnel.stop();
+        }
+        for (ServerSocket socket : new ServerSocket[]{configuredProxy, pacProxy}) {
+            if (socket != null && !socket.isClosed()) {
+                socket.close();
+            }
+        }
+    }
+
+    /** Records the request head it is given and refuses it; nothing has to be relayed. */
+    private ServerSocket recordingProxy(List<String> log) throws Exception {
+        ServerSocket server = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+        Thread acceptor = new Thread(() -> {
+            while (!server.isClosed()) {
+                try (Socket socket = server.accept()) {
+                    BufferedReader in = new BufferedReader(new InputStreamReader(
+                            socket.getInputStream(), StandardCharsets.UTF_8));
+                    List<String> head = new ArrayList<>();
+                    String line;
+                    while ((line = in.readLine()) != null && !line.isEmpty()) {
+                        head.add(line);
+                    }
+                    log.addAll(head);
+                    OutputStream out = socket.getOutputStream();
+                    out.write(("HTTP/1.1 407 Proxy Authentication Required\r\n"
+                            + "Content-Length: 0\r\nConnection: close\r\n\r\n")
+                            .getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+                } catch (IOException closed) {
+                    return;
+                }
+            }
+        });
+        acceptor.setDaemon(true);
+        acceptor.start();
+        return server;
+    }
+
+    /**
+     * @param pacTarget the endpoint the PAC file routes everything to
+     */
+    private void startTunnel(int pacTarget, String wsProxyMode) throws Exception {
+        Path pac = tempDir.resolve("routing.pac");
+        Files.writeString(pac, "function FindProxyForURL(url, host) {"
+                + " return \"PROXY 127.0.0.1:" + pacTarget + "\"; }");
+
+        tunnelPort = TestPorts.free();
+        App app = new App();
+        app.setJettyPort(tunnelPort);
+        app.setClientKey("test_key");
+        app.setClientSecret("test_secret");
+        app.setProxy("127.0.0.1:" + configuredProxy.getLocalPort());
+        app.setProxyAuth(USER_PASSWORD);
+        app.setPacLocal(pac.toString());
+        if (wsProxyMode != null) {
+            app.setWsProxyMode(wsProxyMode);
+        }
+        tunnel = new HttpProxy(app);
+        waitForPort(tunnelPort);
+    }
+
+    private static void waitForPort(int port) throws Exception {
+        for (int i = 0; i < 100; i++) {
+            try (Socket s = new Socket("127.0.0.1", port)) {
+                return;
+            } catch (IOException retry) {
+                Thread.sleep(50);
+            }
+        }
+        throw new IllegalStateException("Proxy did not start on port " + port);
+    }
+
+    private void send(String requestHead, List<String> expectRecordedIn) throws Exception {
+        try (Socket socket = new Socket("127.0.0.1", tunnelPort)) {
+            socket.setSoTimeout(10_000);
+            socket.getOutputStream().write(requestHead.getBytes(StandardCharsets.UTF_8));
+            socket.getOutputStream().flush();
+            new BufferedReader(new InputStreamReader(
+                    socket.getInputStream(), StandardCharsets.UTF_8)).readLine();
+            Await.until("the upstream to record the request head",
+                    () -> !expectRecordedIn.isEmpty());
+        }
+    }
+
+    private static String connectRequest() {
+        return "CONNECT target.example.com:443 HTTP/1.1\r\nHost: target.example.com:443\r\n\r\n";
+    }
+
+    private static String upgradeRequest() {
+        return "GET http://target.example.com/ws HTTP/1.1\r\nHost: target.example.com\r\n"
+                + "Upgrade: websocket\r\nConnection: Upgrade\r\n"
+                + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+    }
+
+    @Test
+    void connectWithholdsTheCredentialFromAProxyOnAnotherPort() throws Exception {
+        configuredProxy = recordingProxy(configuredProxyLog);
+        pacProxy = recordingProxy(pacProxyLog);
+        startTunnel(pacProxy.getLocalPort(), null);
+
+        send(connectRequest(), pacProxyLog);
+
+        assertThat(pacProxyLog).anyMatch(h -> h.startsWith("CONNECT target.example.com:443"));
+        assertThat(pacProxyLog)
+                .as("same host, different port: not the proxy --proxy-userpwd names")
+                .noneMatch(h -> h.startsWith("Proxy-Authorization"));
+        assertThat(configuredProxyLog).isEmpty();
+    }
+
+    @Test
+    void connectStillSendsItToTheProxyThatWasConfigured() throws Exception {
+        // The other half of the rule: narrowing must not withhold the credential from its
+        // rightful recipient when the file routes there.
+        configuredProxy = recordingProxy(configuredProxyLog);
+        pacProxy = recordingProxy(pacProxyLog);
+        startTunnel(configuredProxy.getLocalPort(), null);
+
+        send(connectRequest(), configuredProxyLog);
+
+        assertThat(configuredProxyLog).anyMatch(h -> h.startsWith("Proxy-Authorization: Basic "));
+        assertThat(pacProxyLog).isEmpty();
+    }
+
+    @Test
+    void aWebsocketUpgradeWithholdsItFromAProxyOnAnotherPort() throws Exception {
+        // WebSocket upgrades are intercepted before the CONNECT handler, so they carry their own
+        // copy of this decision -- and had their own copy of the bug.
+        configuredProxy = recordingProxy(configuredProxyLog);
+        pacProxy = recordingProxy(pacProxyLog);
+        startTunnel(pacProxy.getLocalPort(), null);
+
+        send(upgradeRequest(), pacProxyLog);
+
+        assertThat(pacProxyLog).anyMatch(h -> h.startsWith("CONNECT target.example.com:80"));
+        assertThat(pacProxyLog).noneMatch(h -> h.startsWith("Proxy-Authorization"));
+        assertThat(configuredProxyLog).isEmpty();
+    }
+
+    @Test
+    void anUpgradeSentAsGetWithholdsItToo() throws Exception {
+        // --ws-proxy-mode get puts the upgrade on the wire as an absolute-URI request instead of
+        // tunnelling it, which is a second place the header is written.
+        configuredProxy = recordingProxy(configuredProxyLog);
+        pacProxy = recordingProxy(pacProxyLog);
+        startTunnel(pacProxy.getLocalPort(), "get");
+
+        send(upgradeRequest(), pacProxyLog);
+
+        assertThat(pacProxyLog).anyMatch(h -> h.startsWith("GET http://target.example.com/ws"));
+        assertThat(pacProxyLog).noneMatch(h -> h.startsWith("Proxy-Authorization"));
+        assertThat(configuredProxyLog).isEmpty();
+    }
+
+    @Test
+    void aWebsocketUpgradeStillSendsItToTheConfiguredProxy() throws Exception {
+        configuredProxy = recordingProxy(configuredProxyLog);
+        pacProxy = recordingProxy(pacProxyLog);
+        startTunnel(configuredProxy.getLocalPort(), "get");
+
+        send(upgradeRequest(), configuredProxyLog);
+
+        assertThat(configuredProxyLog).anyMatch(h -> h.startsWith("Proxy-Authorization: Basic "));
+        assertThat(pacProxyLog).isEmpty();
+    }
+}

--- a/src/test/java/com/testingbot/tunnel/proxy/SensitiveHeadersTest.java
+++ b/src/test/java/com/testingbot/tunnel/proxy/SensitiveHeadersTest.java
@@ -49,4 +49,49 @@ class SensitiveHeadersTest {
         assertThat(SensitiveHeaders.redactValue("Content-Type", "text/plain"))
                 .isEqualTo("text/plain");
     }
+
+    @Test
+    void isSensitive_recognizesTheRelaysOwnCredentialHeader() {
+        // The account key and secret, which the Selenium relay attaches to everything.
+        assertThat(SensitiveHeaders.isSensitive("TB-Credentials")).isTrue();
+    }
+
+    @Test
+    void redactUrl_masksCredentialShapedQueryValues() {
+        assertThat(SensitiveHeaders.redactUrl("http://host/path?access_key=abc123&page=2"))
+                .isEqualTo("http://host/path?access_key=" + SensitiveHeaders.REDACTED + "&page=2");
+        assertThat(SensitiveHeaders.redactUrl("http://host/?token=t&apiKey=k"))
+                .isEqualTo("http://host/?token=" + SensitiveHeaders.REDACTED
+                        + "&apiKey=" + SensitiveHeaders.REDACTED);
+    }
+
+    @Test
+    void redactUrl_masksUserInfo() {
+        assertThat(SensitiveHeaders.redactUrl("http://user:hunter2@host/path"))
+                .isEqualTo("http://" + SensitiveHeaders.REDACTED + "@host/path");
+    }
+
+    @Test
+    void redactUrl_leavesOrdinaryTargetsAlone() {
+        assertThat(SensitiveHeaders.redactUrl("http://host/path?page=2&q=hello"))
+                .isEqualTo("http://host/path?page=2&q=hello");
+        assertThat(SensitiveHeaders.redactUrl("host:443")).isEqualTo("host:443");
+        assertThat(SensitiveHeaders.redactUrl(null)).isNull();
+    }
+
+    @Test
+    void redactUrl_handlesTheLenientQueryStringsThisProxyForwards() {
+        // Not routed through java.net.URI: these are exactly the targets it refuses, and a
+        // target that failed to parse would then be logged with nothing removed.
+        assertThat(SensitiveHeaders.redactUrl("http://host/?q={json}&secret=s"))
+                .isEqualTo("http://host/?q={json}&secret=" + SensitiveHeaders.REDACTED);
+        assertThat(SensitiveHeaders.redactUrl("http://host/?path=a[0]"))
+                .isEqualTo("http://host/?path=a[0]");
+    }
+
+    @Test
+    void redactUrl_keepsTheFragmentAfterTheQuery() {
+        assertThat(SensitiveHeaders.redactUrl("http://host/?token=t#section"))
+                .isEqualTo("http://host/?token=" + SensitiveHeaders.REDACTED + "#section");
+    }
 }

--- a/src/test/java/ssh/CustomConnectionMonitorTest.java
+++ b/src/test/java/ssh/CustomConnectionMonitorTest.java
@@ -61,7 +61,9 @@ class CustomConnectionMonitorTest {
         private final List<String> calls = new ArrayList<>();
         private boolean shuttingDown;
         private boolean authenticated;
+        private boolean forwardingEstablished = true;
         private RuntimeException connectFailure;
+        private Runnable duringConnect = () -> {};
 
         @Override
         public String getConnectionId() {
@@ -81,6 +83,7 @@ class CustomConnectionMonitorTest {
         @Override
         public void connect() {
             calls.add("connect");
+            duringConnect.run();
             if (connectFailure != null) {
                 throw connectFailure;
             }
@@ -89,6 +92,11 @@ class CustomConnectionMonitorTest {
         @Override
         public boolean isAuthenticated() {
             return authenticated;
+        }
+
+        @Override
+        public boolean isForwardingEstablished() {
+            return forwardingEstablished;
         }
 
         @Override
@@ -131,10 +139,89 @@ class CustomConnectionMonitorTest {
 
     @BeforeEach
     void setUp() {
+        com.testingbot.tunnel.TunnelMetrics.setTunnelUp(false);
         tunnel = new FakeTunnel();
         host = new FakeHost();
         scheduler = new ManualScheduler();
         monitor = new CustomConnectionMonitor(tunnel, host, scheduler, 5000);
+    }
+
+    @Test
+    void anAlreadyQueuedRetryDoesNothingAfterShutdown() {
+        monitor.connectionLost(new RuntimeException("drop"));
+        tunnel.shuttingDown = true;
+        scheduler.fire();
+        assertThat(tunnel.calls).isEmpty();
+        assertThat(host.calls).containsExactly("stopLocalProxy");
+        assertThat(scheduler.hasPending()).isFalse();
+        assertThat(com.testingbot.tunnel.TunnelMetrics.isTunnelUp()).isFalse();
+    }
+
+    @Test
+    void cancellationAlsoStopsACallbackAlreadyDequeuedByTheTimer() {
+        monitor.connectionLost(new RuntimeException("drop"));
+        Runnable dequeued = scheduler.pending;
+        monitor.cancel();
+        dequeued.run();
+        monitor.connectionLost(new RuntimeException("late drop"));
+        assertThat(tunnel.calls).isEmpty();
+        assertThat(host.calls).containsExactly("stopLocalProxy");
+        assertThat(scheduler.hasPending()).isFalse();
+        assertThat(monitor.isRetrying()).isFalse();
+    }
+
+    @Test
+    void cancellationDuringConnectClosesTheSessionWithoutStartingTheProxy() {
+        tunnel.authenticated = true;
+        tunnel.duringConnect = monitor::cancel;
+        monitor.connectionLost(new RuntimeException("drop"));
+        scheduler.fire();
+        assertThat(tunnel.calls).containsExactly("stop", "connect", "stop");
+        assertThat(host.calls).containsExactly("stopLocalProxy");
+        assertThat(scheduler.hasPending()).isFalse();
+        assertThat(com.testingbot.tunnel.TunnelMetrics.isTunnelUp()).isFalse();
+    }
+
+    @Test
+    void cancellationStopsAQueuedLocalProxyRetry() {
+        tunnel.authenticated = true;
+        host.startFailure = new IllegalStateException("port occupied");
+        monitor.connectionLost(new RuntimeException("drop"));
+        scheduler.fire();
+        Runnable dequeued = scheduler.pending;
+        monitor.cancel();
+        host.calls.clear();
+        dequeued.run();
+        assertThat(host.calls).isEmpty();
+        assertThat(scheduler.hasPending()).isFalse();
+    }
+
+    @Test
+    void refusedForwardingStaysUnreadyAndRetriesUntilItSucceeds() {
+        tunnel.authenticated = true;
+        tunnel.forwardingEstablished = false;
+        monitor.connectionLost(new RuntimeException("drop"));
+        scheduler.fire();
+        assertThat(com.testingbot.tunnel.TunnelMetrics.isTunnelUp()).isFalse();
+        assertThat(monitor.isRetrying()).isTrue();
+        assertThat(scheduler.hasPending()).isTrue();
+        tunnel.forwardingEstablished = true;
+        scheduler.fire();
+        assertThat(com.testingbot.tunnel.TunnelMetrics.isTunnelUp()).isTrue();
+        assertThat(scheduler.hasPending()).isFalse();
+    }
+
+    @Test
+    void permanentlyRefusedForwardingEventuallyRebuilds() {
+        tunnel.authenticated = true;
+        tunnel.forwardingEstablished = false;
+        monitor.connectionLost(new RuntimeException("drop"));
+        for (int i = 0; i < CustomConnectionMonitor.MAX_RETRIES; i++) {
+            scheduler.fire();
+        }
+        assertThat(host.calls).contains("rebuildTunnel");
+        assertThat(scheduler.hasPending()).isFalse();
+        assertThat(com.testingbot.tunnel.TunnelMetrics.isTunnelUp()).isFalse();
     }
 
     @Test

--- a/src/test/java/ssh/SSHHostKeyPinningTest.java
+++ b/src/test/java/ssh/SSHHostKeyPinningTest.java
@@ -113,4 +113,24 @@ class SSHHostKeyPinningTest {
         assertThatCode(() -> tunnel = tunnelFor(app)).doesNotThrowAnyException();
     }
 
+    @Test
+    void refusesToConnectUnverified_whenThePolicyRequiresAPin() throws Exception {
+        // The opt-in for networks where an intermediary could answer for the tunnel server:
+        // nothing to verify against means the secret is not sent at all.
+        App app = app();
+        app.setSshHostKeyPolicy("require");
+
+        assertThatThrownBy(() -> tunnelFor(app))
+            .hasMessageContaining("ssh-host-key-policy");
+    }
+
+    @Test
+    void requiringAPinStillConnects_whenOneIsConfigured() throws Exception {
+        App app = app();
+        app.setSshHostKeyPolicy("require");
+        app.setSshHostKeyPins(HostKeyPins.parse(serverFingerprint()));
+
+        assertThatCode(() -> tunnel = tunnelFor(app)).doesNotThrowAnyException();
+    }
+
 }

--- a/src/test/java/ssh/SSHTunnelEmbeddedServerTest.java
+++ b/src/test/java/ssh/SSHTunnelEmbeddedServerTest.java
@@ -176,6 +176,32 @@ class SSHTunnelEmbeddedServerTest {
                 .hasMessageContaining("Connection failed");
     }
 
+    @Test
+    void aPeerThatNeverSendsABannerFailsOnTheDeadlineRatherThanHanging() throws Exception {
+        // The shape of a silently dropping firewall or a proxy that holds the connection open:
+        // the socket is accepted, so there is no connection error, and nothing follows.
+        // session.connect() had no timeout, so startup and every reconnect blocked forever.
+        try (ServerSocket silent = new ServerSocket(0, 50, InetAddress.getLoopbackAddress())) {
+            pool.submit(() -> {
+                try (Socket accepted = silent.accept()) {
+                    Thread.sleep(30_000);
+                } catch (Exception done) {
+                    // test finished
+                }
+            });
+
+            App app = app();
+            app.setHttpDialTimeoutSeconds(1);
+
+            long started = System.currentTimeMillis();
+            assertThatThrownBy(() -> new SSHTunnel(app, "127.0.0.1", silent.getLocalPort(), "127.0.0.1"))
+                    .hasMessageContaining("Connection failed");
+            assertThat(System.currentTimeMillis() - started)
+                    .as("the configured dial timeout is what bounds this")
+                    .isLessThan(15_000);
+        }
+    }
+
     /* -------------------------------------------------------------- port forwarding */
 
     @Test
@@ -442,6 +468,66 @@ class SSHTunnelEmbeddedServerTest {
             assertThat(SSHTunnel.localForwardingActive(
                     tunnel.getSession().getPortForwardingL(), app.getSSHPort())).isFalse();
         }
+    }
+
+    @Test
+    void aServerRefusingTheReverseForwardLeavesTheTunnelNotForwarding() throws Exception {
+        // Authentication succeeding is not the same as the tunnel working. createPortForwarding()
+        // recorded this failure and returned normally, and the reconnect path marked the tunnel
+        // up regardless -- so /readyz advertised a session that could carry no browser traffic.
+        sshd.setForwardingFilter(new org.apache.sshd.server.forward.AcceptAllForwardingFilter() {
+            @Override
+            public boolean canListen(SshdSocketAddress address,
+                                     org.apache.sshd.common.session.Session session) {
+                // Everything else is permitted: the session authenticates and the local forward
+                // works, so only the reverse direction is missing.
+                return false;
+            }
+        });
+        hub = serverAnswering("HUB");
+        localProxy = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+        App app = app();
+        app.setHubPort(hub.getLocalPort());
+        app.setJettyPort(localProxy.getLocalPort());
+        tunnel = connect(app, "127.0.0.1");
+
+        tunnel.createPortForwarding();
+
+        assertThat(tunnel.isAuthenticated())
+                .as("the session itself is fine, which is what made this invisible")
+                .isTrue();
+        assertThat(tunnel.isForwardingEstablished())
+                .as("no reverse forward means no browser traffic, so this is not a ready tunnel")
+                .isFalse();
+    }
+
+    @Test
+    void bothDirectionsEstablishedMeansForwarding() throws Exception {
+        hub = serverAnswering("HUB");
+        localProxy = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+        App app = app();
+        app.setHubPort(hub.getLocalPort());
+        app.setJettyPort(localProxy.getLocalPort());
+        tunnel = connect(app, "127.0.0.1");
+
+        tunnel.createPortForwarding();
+
+        assertThat(tunnel.isForwardingEstablished()).isTrue();
+    }
+
+    @Test
+    void aStoppedTunnelIsNoLongerForwarding() throws Exception {
+        hub = serverAnswering("HUB");
+        localProxy = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+        App app = app();
+        app.setHubPort(hub.getLocalPort());
+        app.setJettyPort(localProxy.getLocalPort());
+        tunnel = connect(app, "127.0.0.1");
+        tunnel.createPortForwarding();
+
+        tunnel.stop();
+
+        assertThat(tunnel.isForwardingEstablished()).isFalse();
     }
 
     @Test

--- a/src/test/java/ssh/TestTunnels.java
+++ b/src/test/java/ssh/TestTunnels.java
@@ -1,0 +1,30 @@
+package ssh;
+
+import com.testingbot.tunnel.App;
+
+/**
+ * Test-only access to the SSHTunnel constructor that takes a port and hub host.
+ *
+ * <p>Those two are fixed in production, so the constructor carrying them is package-private.
+ * Tests outside this package -- anything that boots a whole {@link App} against an in-process SSH
+ * server -- need it without widening the production API.
+ */
+public final class TestTunnels {
+
+    private TestTunnels() {
+    }
+
+    public static SSHTunnel connect(App app, String server, int sshPort, String hubHost)
+            throws Exception {
+        return new SSHTunnel(app, server, sshPort, hubHost);
+    }
+
+    /**
+     * @param remoteProxyPort where the tunnel server listens for browser traffic; two tunnel
+     *                        servers in one JVM cannot both bind the production 2010
+     */
+    public static SSHTunnel connect(App app, String server, int sshPort, String hubHost,
+                                    int remoteProxyPort) throws Exception {
+        return new SSHTunnel(app, server, sshPort, hubHost, remoteProxyPort);
+    }
+}


### PR DESCRIPTION
Two related passes. The first works through an external review of the whole client; the second covers the case that review's recommendations kept running into — the tunnel used as a library rather than a process.

## The review's nine findings

1. **The SSH server was unverified whenever no fingerprint was available**, and the account secret is that connection's password. `--ssh-host-key` pins a SHA-256 fingerprint, `--ssh-host-key-policy require` refuses to connect without one. The default stays permissive-with-warning because the service does not publish fingerprints for every tunnel server yet, so requiring one would refuse connections that work today. A fingerprint the API *does* send but that cannot be parsed is now fatal: sending the field means the connection was meant to be verified, so an unusable value is a bug or a rewrite, and continuing would hand over the secret on exactly the occasion somebody interfered.
2. **Upstream proxy credentials were scoped to a hostname.** On loopback every peer matches a hostname, so a PAC file naming `127.0.0.1` on any other port was sent `--proxy-userpwd`, or the SOCKS5 credentials, on CONNECT and WebSocket upgrades. Scoped to the whole endpoint now — protocol, host and port — as the plain-HTTP path already was.
3. **A queued reconnect survived shutdown**: it re-dialled SSH, restarted services and set the tunnel ready again against an App that had already released its proxy. `stop()` cancels the reconnect monitor, and every step of a retry checks that cancellation.
4. **A reconnect reported ready whatever `createPortForwarding()` found**, so a server that authenticated and then refused the reverse forward advertised a tunnel that could carry nothing. Both paths now gate on `isForwardingEstablished()`, and a refusal retries and then rebuilds.
5. **The API client only ever sent username and password**, so with `--proxy-auth-scheme negotiate` the tunnel could not register at all on a proxy requiring Kerberos — while SSH and browser traffic, which have their own Negotiate support, were fine.
6. **A boolean set to `false` in a `--config` file produced no argument**, so the environment supplied its own: `shared=false` with `TESTINGBOT_SHARED=true` gave a shared tunnel. The configured keys now travel with the expanded arguments.
7. **The startup self-test fought the configuration.** It asked the API to fetch a loopback callback, which `--localhost-policy deny`, `--allow-hosts`, `--fast-fail-regexps`, `--connect-to` and `--pac-local` each legitimately prevent, and it dialled the API past `--proxy-testingbot` and `--cacert-file`. It is skipped rather than failed in the first case and goes through the control client in the second. A failure is also retried now: readiness is gated on this, so a check that failed for a transient reason pinned a healthy tunnel at 503 for the life of the session, with only a dropped connection re-running anything.
8. **PAC rules were evaluated against a synthetic `scheme://host:port/`**, so a rule written on a path was followed by `--pac-test` and not by traffic. The real URL is used on the HTTP and WebSocket paths; CONNECT carries no path and keeps a synthetic `https://` URL, which is now stated.
9. **Request formatting asked `--proxy` whether a proxy was in use**, so a proxy named only by a PAC file was sent origin-form — the 400 from Squid the absolute-form fix was for, on the path nothing looked at.

Also from the review's improvements: `session.connect()` is bounded (a peer that accepts the socket and sends no banner blocked startup and every reconnect), request URLs are redacted in logs alongside `TB-Credentials`, and the manual Maven Central publish workflow gets the same test gate the tagged release has — it deploys with `-DskipTests` and a Central version cannot be withdrawn.

## Embedded mode

`AppEmbeddedTest` covered only the failure paths, and the command line was the only thing that ever ran the whole of `boot()`, so everything that breaks when an App shares a JVM had nowhere to fail:

- readiness was a process-wide gauge, so two tunnels in one JVM were one tunnel: each metrics port answered for whichever wrote last, and stopping either reported both as down. It is per App now, mirrored to the gauge for the single-tunnel case every command line run is;
- `stop()` left the JVM's default `Authenticator` replaced and this tunnel's SOCKS credentials registered, so a stopped tunnel went on answering for the proxy it named, and a tunnel per job stacked one authenticator per job. Both are undone;
- the self-test named `api.testingbot.com` literally, so an embedder pointing its `Api` elsewhere had two readiness checks following the configuration and the third talking to production — which, now that readiness is gated on it, failed the whole tunnel;
- `boot()` returns once the tunnel is *created*, so a caller starting tests when it returned raced the tunnel it had just asked for. `awaitReady(Duration)` and `getSetupFailure()` are what to wait on; `awaitReady` returns false as soon as setup gives up rather than waiting out the timeout;
- the new-version notice went to the host application's stderr, which it cannot switch off. Logged now.

`AppEmbeddedLifecycleTest` boots whole tunnels in-process against a stub API and Apache MINA SSHD, through `createApi` and `createTunnel`; two of the three startup checks are the real ones and the stub really performs the callback, so the third runs too. `SSHTunnel`'s reverse-forward port joins `sshPort` and `hubHost` as a test parameter for the same reason those exist: two tunnel servers are two machines in production and two listeners here, which cannot both bind 2010.

## Notes for review

- Every fix has a test that fails without it.
- Three things stay process-wide and are documented rather than half-fixed: the Prometheus registry, the `Statistics` counters, and uptime.
- New options: `--ssh-host-key`, `--ssh-host-key-policy`. Behaviour changes are called out in `CLAUDE.md` and the `CHANGELOG`.
- 1002 tests, `mvn verify` green locally, coverage gate unchanged.
